### PR TITLE
Fix `Create` and `Each` extensions

### DIFF
--- a/csharp/Platform.Data/ILinksExtensions.cs
+++ b/csharp/Platform.Data/ILinksExtensions.cs
@@ -16,7 +16,7 @@ namespace Platform.Data
     /// </summary>
     public static class ILinksExtensions
     {
-        public static TLink Create<TLink>(this ILinks<TLink, LinksConstants<TLink>> links) => links.Create(Array.Empty<TLink>());
+        public static TLink Create<TLink>(this ILinks<TLink, LinksConstants<TLink>> links) => links.Create(new List<TLink>());
 
         public static TLink Create<TLink>(this ILinks<TLink, LinksConstants<TLink>> links, IList<TLink> substitution)
         {

--- a/csharp/Platform.Data/ILinksExtensions.cs
+++ b/csharp/Platform.Data/ILinksExtensions.cs
@@ -139,7 +139,7 @@ namespace Platform.Data
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TLinkAddress Each<TLinkAddress, TConstants>(this ILinks<TLinkAddress, TConstants> links, ReadHandler<TLinkAddress> handler, params TLinkAddress[] restrictions)
             where TConstants : LinksConstants<TLinkAddress>
-            => links.Each(handler, restrictions);
+            => links.Each(restrictions, handler);
 
         /// <summary>
         /// Возвращает части-значения для связи с указанным индексом.

--- a/csharp/Platform.Data/ILinksExtensions.cs
+++ b/csharp/Platform.Data/ILinksExtensions.cs
@@ -16,7 +16,7 @@ namespace Platform.Data
     /// </summary>
     public static class ILinksExtensions
     {
-        public static TLink Create<TLink>(this ILinks<TLink, LinksConstants<TLink>> links) => links.Create(null);
+        public static TLink Create<TLink>(this ILinks<TLink, LinksConstants<TLink>> links) => links.Create(Array.Empty<TLink>());
 
         public static TLink Create<TLink>(this ILinks<TLink, LinksConstants<TLink>> links, IList<TLink> substitution)
         {

--- a/csharp/Platform.Data/ILinksExtensions.cs
+++ b/csharp/Platform.Data/ILinksExtensions.cs
@@ -22,7 +22,7 @@ namespace Platform.Data
         {
             var constants = links.Constants;
             var result = constants.Null;
-            links.Create(substitution, (_, after) =>
+            links.Create(new List<TLink>(), (_, after) =>
             {
                 result = after[constants.IndexPart];
                 return constants.Continue;

--- a/csharp/Platform.Data/Platform.Data.csproj
+++ b/csharp/Platform.Data/Platform.Data.csproj
@@ -4,7 +4,7 @@
     <Description>LinksPlatform's Platform.Data Class Library</Description>
     <Copyright>konard, FreePhoenix888</Copyright>
     <AssemblyTitle>Platform.Data</AssemblyTitle>
-    <VersionPrefix>0.7.3</VersionPrefix>
+    <VersionPrefix>0.7.4</VersionPrefix>
     <Authors>konard, FreePhoenix888</Authors>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;net5</TargetFrameworks>
     <AssemblyName>Platform.Data</AssemblyName>
@@ -24,7 +24,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Delete extension with TLink is added.</PackageReleaseNotes>
+    <PackageReleaseNotes>Create extensions is fixed.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">

--- a/csharp/Platform.Data/Platform.Data.csproj
+++ b/csharp/Platform.Data/Platform.Data.csproj
@@ -24,7 +24,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Create extension is fixed.</PackageReleaseNotes>
+    <PackageReleaseNotes>Create, Each extensions are fixed.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">

--- a/csharp/Platform.Data/Platform.Data.csproj
+++ b/csharp/Platform.Data/Platform.Data.csproj
@@ -24,7 +24,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Create extensions is fixed.</PackageReleaseNotes>
+    <PackageReleaseNotes>Create extension is fixed.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">


### PR DESCRIPTION
- Pass empty array instead of null in `Create`
- [C#] 0.7.4
- Fix typo
- Fix `Each` extension
- Update `ReleaseNotes`
- Pass empty `List` to `Create`
- Pass empty `List` to `Create` extension that have `substitution` parameter
