### PR TITLE
Format all C++ code for consistent style and implement PR style checking

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,55 @@
+# Based on observed code style in the repository
+BasedOnStyle: LLVM
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+
+# Braces
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+
+# Spacing
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceAfterTemplateKeyword: false
+
+# Alignment
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+# Line length and wrapping
+ColumnLimit: 120
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllArgumentsOnNextLine: true
+BinPackParameters: false
+BinPackArguments: false
+
+# Includes
+SortIncludes: true
+IncludeBlocks: Preserve
+
+# Namespaces
+NamespaceIndentation: None
+CompactNamespaces: false
+
+# Access modifiers
+AccessModifierOffset: -4
+
+# Other formatting
+ReflowComments: true
+FixNamespaceComments: true
+SpaceBeforeRangeBasedForLoopColon: true
+Standard: c++20

--- a/.github/workflows/cpp-format-check.yml
+++ b/.github/workflows/cpp-format-check.yml
@@ -1,0 +1,52 @@
+name: C++ Format Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'cpp/**/*.h'
+      - 'cpp/**/*.hpp'
+      - 'cpp/**/*.cpp'
+      - 'cpp/**/*.cc'
+      - 'cpp/**/*.c'
+      - '.clang-format'
+      - 'format-check.sh'
+
+jobs:
+  format-check:
+    name: Check C++ Code Formatting
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Install clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
+        
+    - name: Verify clang-format version
+      run: clang-format --version
+      
+    - name: Run format check
+      run: |
+        chmod +x ./format-check.sh
+        ./format-check.sh
+        
+    - name: Format check failed
+      if: failure()
+      run: |
+        echo ""
+        echo "❌ C++ code formatting check failed!"
+        echo ""
+        echo "Some files are not properly formatted according to .clang-format"
+        echo ""
+        echo "To fix formatting issues:"
+        echo "1. Run: ./format-apply.sh"
+        echo "2. Commit the changes"
+        echo "3. Push to update your PR"
+        echo ""
+        exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/127
-Your prepared branch: issue-127-b57eebe4
-Your prepared working directory: /tmp/gh-issue-solver-1757579488990
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/127
+Your prepared branch: issue-127-b57eebe4
+Your prepared working directory: /tmp/gh-issue-solver-1757579488990
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ Interface [ILinks\<TLinkAddress, TConstants\>](https://linksplatform.github.io/D
 *   [Platform.Numbers](https://github.com/linksplatform/Numbers)
 *   [Platform.Setters](https://github.com/linksplatform/Setters)
 
+## C++ Code Formatting
+
+This repository uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to ensure consistent C++ code formatting. The formatting rules are defined in `.clang-format`.
+
+### Format Commands
+
+Similar to Java's `./gradlew spotlessCheck` and `./gradlew spotlessApply`, we provide equivalent scripts for C++:
+
+- **Check formatting**: `./format-check.sh` - Checks if all C++ files are properly formatted
+- **Apply formatting**: `./format-apply.sh` - Formats all C++ files according to the style guide
+
+### CI Integration
+
+Pull requests automatically check C++ code formatting using GitHub Actions. If formatting issues are found, the PR will be marked as failed until the code is properly formatted.
+
+To fix formatting issues in your PR:
+1. Run `./format-apply.sh` to format your code
+2. Commit and push the changes
+
 ## Dependent libraries
 *   [Platform.Data.Doublets](https://github.com/linksplatform/Data.Doublets)
 *   [Platform.Data.Triplets](https://github.com/linksplatform/Data.Triplets)

--- a/cpp/Platform.Data.Tests/AllTests.cpp
+++ b/cpp/Platform.Data.Tests/AllTests.cpp
@@ -2,6 +2,6 @@
 #include <gtest/gtest.h>
 
 #include "HybridTests.cpp"
-#include "LinksConstantsTests.cpp"
 #include "ILinksTests.cpp"
+#include "LinksConstantsTests.cpp"
 #include "PointTests.cpp"

--- a/cpp/Platform.Data.Tests/HybridTests.cpp
+++ b/cpp/Platform.Data.Tests/HybridTests.cpp
@@ -1,10 +1,10 @@
 ﻿namespace Platform::Data::Tests
 {
-    TEST(HybridTests, ObjectConstructorTest)
-    {
-        ASSERT_EQ(0, Hybrid(std::uint8_t{128}).AbsoluteValue());
-        ASSERT_EQ(1, Hybrid(static_cast<uint8_t>(-1)).AbsoluteValue());
-        ASSERT_EQ(0, Hybrid(std::uint8_t{0}).AbsoluteValue());
-        ASSERT_EQ(1, Hybrid(std::uint8_t{1}).AbsoluteValue());
-    };
-}
+TEST(HybridTests, ObjectConstructorTest)
+{
+    ASSERT_EQ(0, Hybrid(std::uint8_t{128}).AbsoluteValue());
+    ASSERT_EQ(1, Hybrid(static_cast<uint8_t>(-1)).AbsoluteValue());
+    ASSERT_EQ(0, Hybrid(std::uint8_t{0}).AbsoluteValue());
+    ASSERT_EQ(1, Hybrid(std::uint8_t{1}).AbsoluteValue());
+};
+} // namespace Platform::Data::Tests

--- a/cpp/Platform.Data.Tests/ILinksTests.cpp
+++ b/cpp/Platform.Data.Tests/ILinksTests.cpp
@@ -1,40 +1,61 @@
 namespace Platform::Data::Tests
 {
-    template<std::integral TLinkAddress = std::uint64_t, LinksConstants<TLinkAddress> VConstants = LinksConstants<TLinkAddress>{true}, typename TLink = std::vector<TLinkAddress>, typename TReadHandler = std::function<TLinkAddress(TLink)>, typename TWriteHandler = std::function<TLinkAddress(TLink, TLink)>>
-    struct Links : public ILinks<LinksOptions<TLinkAddress, VConstants, TLink,TReadHandler, TWriteHandler>>
+template<std::integral TLinkAddress = std::uint64_t,
+         LinksConstants<TLinkAddress> VConstants = LinksConstants<TLinkAddress>{true},
+         typename TLink = std::vector<TLinkAddress>,
+         typename TReadHandler = std::function<TLinkAddress(TLink)>,
+         typename TWriteHandler = std::function<TLinkAddress(TLink, TLink)>>
+struct Links : public ILinks<LinksOptions<TLinkAddress, VConstants, TLink, TReadHandler, TWriteHandler>>
+{
+    using base = ILinks<LinksOptions<TLinkAddress, VConstants, TLink, TReadHandler, TWriteHandler>>;
+    using base::Constants;
+    using typename base::LinkAddressType;
+    using typename base::LinkType;
+    using typename base::ReadHandlerType;
+    using typename base::WriteHandlerType;
+
+    LinkAddressType Count(const std::vector<LinkAddressType>& restriction) const override
     {
-        using base = ILinks<LinksOptions<TLinkAddress, VConstants, TLink, TReadHandler, TWriteHandler>>;
-        using typename base::LinkAddressType;
-        using typename base::LinkType;
-        using typename base::WriteHandlerType;
-        using typename base::ReadHandlerType;
-        using base::Constants;
-
-        LinkAddressType Count(const std::vector<LinkAddressType>& restriction) const override { return 0; };
-
-        LinkAddressType Each(const std::vector<LinkAddressType>& restriction, const ReadHandlerType& handler) const override { return 0; };
-
-        LinkAddressType Create(const std::vector<LinkAddressType>& restriction, const WriteHandlerType& handler) override { return 0; };
-
-        LinkAddressType Update(const std::vector<LinkAddressType>& restriction, const std::vector<LinkAddressType>& substitution, const WriteHandlerType& handler) override { return 0; };
-
-        LinkAddressType Delete(const std::vector<LinkAddressType>& restriction, const WriteHandlerType& handler) override { return 0; };
+        return 0;
     };
-    TEST(ILinksDeriverTest, ConstructorAndMethodsTest)
+
+    LinkAddressType Each(const std::vector<LinkAddressType>& restriction, const ReadHandlerType& handler) const override
     {
-        using TLinkAddress = uint64_t;
-        using TLink = std::vector<TLinkAddress>;
-        using TWriteHandler = std::function<TLinkAddress(TLink, TLink)>;
-        using TReadHandler = std::function<TLinkAddress(TLink)>;
-        Links<TLinkAddress> storage{};
-        const Links<TLinkAddress> const_links {storage};
-        const TLinkAddress linkAddress {1};
-        Create(storage, linkAddress);
-        Update(storage, TLink{1}, TLink{1, 1});
-        storage.Count(TLink{1});
-        const_links.Count(TLink{1});
-        storage.Each(TLink{1}, [](const TLink& link){ return 1; });
-        const_links.Each(TLink{1}, [](const TLink& link){ return 1; });
-        Delete(storage, TLink{1});
-    }
+        return 0;
+    };
+
+    LinkAddressType Create(const std::vector<LinkAddressType>& restriction, const WriteHandlerType& handler) override
+    {
+        return 0;
+    };
+
+    LinkAddressType Update(const std::vector<LinkAddressType>& restriction,
+                           const std::vector<LinkAddressType>& substitution,
+                           const WriteHandlerType& handler) override
+    {
+        return 0;
+    };
+
+    LinkAddressType Delete(const std::vector<LinkAddressType>& restriction, const WriteHandlerType& handler) override
+    {
+        return 0;
+    };
+};
+TEST(ILinksDeriverTest, ConstructorAndMethodsTest)
+{
+    using TLinkAddress = uint64_t;
+    using TLink = std::vector<TLinkAddress>;
+    using TWriteHandler = std::function<TLinkAddress(TLink, TLink)>;
+    using TReadHandler = std::function<TLinkAddress(TLink)>;
+    Links<TLinkAddress> storage{};
+    const Links<TLinkAddress> const_links{storage};
+    const TLinkAddress linkAddress{1};
+    Create(storage, linkAddress);
+    Update(storage, TLink{1}, TLink{1, 1});
+    storage.Count(TLink{1});
+    const_links.Count(TLink{1});
+    storage.Each(TLink{1}, [](const TLink& link) { return 1; });
+    const_links.Each(TLink{1}, [](const TLink& link) { return 1; });
+    Delete(storage, TLink{1});
 }
+} // namespace Platform::Data::Tests

--- a/cpp/Platform.Data.Tests/LinksConstantsTests.cpp
+++ b/cpp/Platform.Data.Tests/LinksConstantsTests.cpp
@@ -1,39 +1,40 @@
 ﻿namespace Platform::Data::Tests
 {
-    TEST(LinksConstantsTests, ConstructorTest)
-    {
-        using namespace Platform::Data;
+TEST(LinksConstantsTests, ConstructorTest)
+{
+    using namespace Platform::Data;
 
-        auto constants = LinksConstants<std::uint64_t>(true);
-        ASSERT_EQ(Hybrid<std::uint64_t>::ExternalZero, constants.ExternalReferencesRange.Minimum);
-        ASSERT_EQ(std::numeric_limits<std::uint64_t>::max(), constants.ExternalReferencesRange.Maximum);
-    }
-
-    template<std::signed_integral TSigned, typename TUnsigned = std::make_unsigned_t<TSigned>>
-    static void TestExternalReferences()
-    {
-        using namespace Platform::Data;
-        using namespace Platform::Ranges;
-
-        constexpr TUnsigned unsingedOne = 1;
-        constexpr TUnsigned half = std::numeric_limits<TSigned>::max();
-        constexpr LinksConstants<TUnsigned> constants {Range{unsingedOne, half}, Range{TUnsigned(half + unsingedOne), std::numeric_limits<TUnsigned>::max()}};
-
-        auto minimum = Hybrid<TUnsigned>(0, true);
-        auto maximum = Hybrid<TUnsigned>(half, true);
-        ASSERT_TRUE((IsExternalReference<TUnsigned,constants>(minimum.Value)));
-        ASSERT_TRUE(minimum.IsExternal());
-        ASSERT_FALSE(minimum.IsInternal());
-        ASSERT_TRUE((IsExternalReference<TUnsigned, constants>(maximum.Value)));
-        ASSERT_TRUE(maximum.IsExternal());
-        ASSERT_FALSE(maximum.IsInternal());
-    }
-
-    TEST(LinksConstantsTests, ExternalReferencesTest)
-    {
-        TestExternalReferences<std::int64_t>();
-        TestExternalReferences<std::int32_t>();
-        TestExternalReferences<std::int16_t>();
-        TestExternalReferences<std::int8_t>();
-    }
+    auto constants = LinksConstants<std::uint64_t>(true);
+    ASSERT_EQ(Hybrid<std::uint64_t>::ExternalZero, constants.ExternalReferencesRange.Minimum);
+    ASSERT_EQ(std::numeric_limits<std::uint64_t>::max(), constants.ExternalReferencesRange.Maximum);
 }
+
+template<std::signed_integral TSigned, typename TUnsigned = std::make_unsigned_t<TSigned>>
+static void TestExternalReferences()
+{
+    using namespace Platform::Data;
+    using namespace Platform::Ranges;
+
+    constexpr TUnsigned unsingedOne = 1;
+    constexpr TUnsigned half = std::numeric_limits<TSigned>::max();
+    constexpr LinksConstants<TUnsigned> constants{
+        Range{unsingedOne, half}, Range{TUnsigned(half + unsingedOne), std::numeric_limits<TUnsigned>::max()}};
+
+    auto minimum = Hybrid<TUnsigned>(0, true);
+    auto maximum = Hybrid<TUnsigned>(half, true);
+    ASSERT_TRUE((IsExternalReference<TUnsigned, constants>(minimum.Value)));
+    ASSERT_TRUE(minimum.IsExternal());
+    ASSERT_FALSE(minimum.IsInternal());
+    ASSERT_TRUE((IsExternalReference<TUnsigned, constants>(maximum.Value)));
+    ASSERT_TRUE(maximum.IsExternal());
+    ASSERT_FALSE(maximum.IsInternal());
+}
+
+TEST(LinksConstantsTests, ExternalReferencesTest)
+{
+    TestExternalReferences<std::int64_t>();
+    TestExternalReferences<std::int32_t>();
+    TestExternalReferences<std::int16_t>();
+    TestExternalReferences<std::int8_t>();
+}
+} // namespace Platform::Data::Tests

--- a/cpp/Platform.Data.Tests/PointTests.cpp
+++ b/cpp/Platform.Data.Tests/PointTests.cpp
@@ -1,16 +1,16 @@
 namespace Platform::Data::Tests
 {
-    TEST(PointTests, IsPartialPointTest)
-    {
-        ASSERT_TRUE(IsPartialPoint(1, 1, 2));
-        ASSERT_TRUE(IsPartialPoint(1, 2, 1));
-        ASSERT_TRUE(IsPartialPoint(1, 1, 1));
-        ASSERT_FALSE(IsPartialPoint(1, 2, 3));
-    };
-    TEST(PointTests, IsFullPointTest)
-    {
-        ASSERT_TRUE(IsFullPoint(1, 1, 1));
-        ASSERT_FALSE(IsFullPoint(1, 2, 1));
-        ASSERT_FALSE(IsFullPoint(1, 1, 2));
-    };
-}
+TEST(PointTests, IsPartialPointTest)
+{
+    ASSERT_TRUE(IsPartialPoint(1, 1, 2));
+    ASSERT_TRUE(IsPartialPoint(1, 2, 1));
+    ASSERT_TRUE(IsPartialPoint(1, 1, 1));
+    ASSERT_FALSE(IsPartialPoint(1, 2, 3));
+};
+TEST(PointTests, IsFullPointTest)
+{
+    ASSERT_TRUE(IsFullPoint(1, 1, 1));
+    ASSERT_FALSE(IsFullPoint(1, 2, 1));
+    ASSERT_FALSE(IsFullPoint(1, 1, 2));
+};
+} // namespace Platform::Data::Tests

--- a/cpp/Platform.Data/Exceptions/ArgumentLinkDoesNotExistsException.h
+++ b/cpp/Platform.Data/Exceptions/ArgumentLinkDoesNotExistsException.h
@@ -1,20 +1,51 @@
 ﻿namespace Platform::Data::Exceptions
 {
-    template <typename ...> class ArgumentLinkDoesNotExistsException;
-    template <typename TLinkAddress> class ArgumentLinkDoesNotExistsException<TLinkAddress> : public std::invalid_argument
+template<typename...> class ArgumentLinkDoesNotExistsException;
+template<typename TLinkAddress> class ArgumentLinkDoesNotExistsException<TLinkAddress> : public std::invalid_argument
+{
+public:
+    ArgumentLinkDoesNotExistsException(TLinkAddress link, std::string argumentName)
+        : std::invalid_argument(FormatMessage(link, argumentName), argumentName)
     {
-        public: ArgumentLinkDoesNotExistsException(TLinkAddress link, std::string argumentName) : std::invalid_argument(FormatMessage(link, argumentName), argumentName) { }
+    }
 
-        public: ArgumentLinkDoesNotExistsException(TLinkAddress link) : std::invalid_argument(FormatMessage(link)) { }
+public:
+    ArgumentLinkDoesNotExistsException(TLinkAddress link) : std::invalid_argument(FormatMessage(link))
+    {
+    }
 
-        public: ArgumentLinkDoesNotExistsException(std::string message, const std::exception& innerException) : std::invalid_argument(message, innerException) { }
+public:
+    ArgumentLinkDoesNotExistsException(std::string message, const std::exception& innerException)
+        : std::invalid_argument(message, innerException)
+    {
+    }
 
-        public: ArgumentLinkDoesNotExistsException(std::string message) : std::invalid_argument(message) { }
+public:
+    ArgumentLinkDoesNotExistsException(std::string message) : std::invalid_argument(message)
+    {
+    }
 
-        public: ArgumentLinkDoesNotExistsException() { }
+public:
+    ArgumentLinkDoesNotExistsException()
+    {
+    }
 
-        private: static std::string FormatMessage(TLinkAddress link, std::string argumentName) { return std::string("Связь [").append(Platform::Converters::To<std::string>(link)).append("] переданная в аргумент [").append(argumentName).append("] не существует."); }
+private:
+    static std::string FormatMessage(TLinkAddress link, std::string argumentName)
+    {
+        return std::string("Связь [")
+            .append(Platform::Converters::To<std::string>(link))
+            .append("] переданная в аргумент [")
+            .append(argumentName)
+            .append("] не существует.");
+    }
 
-        private: static std::string FormatMessage(TLinkAddress link) { return std::string("Связь [").append(Platform::Converters::To<std::string>(link)).append("] переданная в качестве аргумента не существует."); }
-    };
-}
+private:
+    static std::string FormatMessage(TLinkAddress link)
+    {
+        return std::string("Связь [")
+            .append(Platform::Converters::To<std::string>(link))
+            .append("] переданная в качестве аргумента не существует.");
+    }
+};
+} // namespace Platform::Data::Exceptions

--- a/cpp/Platform.Data/Exceptions/ArgumentLinkHasDependenciesException.h
+++ b/cpp/Platform.Data/Exceptions/ArgumentLinkHasDependenciesException.h
@@ -1,20 +1,52 @@
 ﻿namespace Platform::Data::Exceptions
 {
-    template <typename ...> class ArgumentLinkHasDependenciesException;
-    template <typename TLinkAddress> class ArgumentLinkHasDependenciesException<TLinkAddress> : public std::invalid_argument
+template<typename...> class ArgumentLinkHasDependenciesException;
+template<typename TLinkAddress> class ArgumentLinkHasDependenciesException<TLinkAddress> : public std::invalid_argument
+{
+public:
+    ArgumentLinkHasDependenciesException(TLinkAddress link, std::string paramName)
+        : std::invalid_argument(FormatMessage(link, paramName), paramName)
     {
-        public: ArgumentLinkHasDependenciesException(TLinkAddress link, std::string paramName) : std::invalid_argument(FormatMessage(link, paramName), paramName) { }
+    }
 
-        public: ArgumentLinkHasDependenciesException(TLinkAddress link) : std::invalid_argument(FormatMessage(link)) { }
+public:
+    ArgumentLinkHasDependenciesException(TLinkAddress link) : std::invalid_argument(FormatMessage(link))
+    {
+    }
 
-        public: ArgumentLinkHasDependenciesException(std::string message, const std::exception& innerException) : std::invalid_argument(message, innerException) { }
+public:
+    ArgumentLinkHasDependenciesException(std::string message, const std::exception& innerException)
+        : std::invalid_argument(message, innerException)
+    {
+    }
 
-        public: ArgumentLinkHasDependenciesException(std::string message) : std::invalid_argument(message) { }
+public:
+    ArgumentLinkHasDependenciesException(std::string message) : std::invalid_argument(message)
+    {
+    }
 
-        public: ArgumentLinkHasDependenciesException() { }
+public:
+    ArgumentLinkHasDependenciesException()
+    {
+    }
 
-        private: static std::string FormatMessage(TLinkAddress link, std::string paramName) { return std::string("У связи [").append(Platform::Converters::To<std::string>(link)).append("] переданной в аргумент [").append(paramName).append("] присутствуют зависимости, которые препятствуют изменению её внутренней структуры."); }
+private:
+    static std::string FormatMessage(TLinkAddress link, std::string paramName)
+    {
+        return std::string("У связи [")
+            .append(Platform::Converters::To<std::string>(link))
+            .append("] переданной в аргумент [")
+            .append(paramName)
+            .append("] присутствуют зависимости, которые препятствуют изменению её внутренней структуры.");
+    }
 
-        private: static std::string FormatMessage(TLinkAddress link) { return std::string("У связи [").append(Platform::Converters::To<std::string>(link)).append("] переданной в качестве аргумента присутствуют зависимости, которые препятствуют изменению её внутренней структуры."); }
-    };
-}
+private:
+    static std::string FormatMessage(TLinkAddress link)
+    {
+        return std::string("У связи [")
+            .append(Platform::Converters::To<std::string>(link))
+            .append("] переданной в качестве аргумента присутствуют зависимости, которые препятствуют изменению её "
+                    "внутренней структуры.");
+    }
+};
+} // namespace Platform::Data::Exceptions

--- a/cpp/Platform.Data/Exceptions/LinkWithSameValueAlreadyExistsException.h
+++ b/cpp/Platform.Data/Exceptions/LinkWithSameValueAlreadyExistsException.h
@@ -1,13 +1,24 @@
 ﻿namespace Platform::Data::Exceptions
 {
-    class LinkWithSameValueAlreadyExistsException : public std::exception
+class LinkWithSameValueAlreadyExistsException : public std::exception
+{
+public:
+    inline static std::string DefaultMessage = "Связь с таким же значением уже существует.";
+
+public:
+    LinkWithSameValueAlreadyExistsException(std::string message, const std::exception& innerException)
+        : base(message, innerException)
     {
-        public: inline static std::string DefaultMessage = "Связь с таким же значением уже существует.";
+    }
 
-        public: LinkWithSameValueAlreadyExistsException(std::string message, const std::exception& innerException) : base(message, innerException) { }
+public:
+    LinkWithSameValueAlreadyExistsException(std::string message) : base(message)
+    {
+    }
 
-        public: LinkWithSameValueAlreadyExistsException(std::string message) : base(message) { }
-
-        public: LinkWithSameValueAlreadyExistsException() : base(DefaultMessage) { }
-    };
-}
+public:
+    LinkWithSameValueAlreadyExistsException() : base(DefaultMessage)
+    {
+    }
+};
+} // namespace Platform::Data::Exceptions

--- a/cpp/Platform.Data/Exceptions/LinksLimitReachedException.h
+++ b/cpp/Platform.Data/Exceptions/LinksLimitReachedException.h
@@ -1,16 +1,35 @@
 ﻿namespace Platform::Data::Exceptions
 {
-    template <typename ...> class LinksLimitReachedException;
-    template <typename TLinkAddress> class LinksLimitReachedException<TLinkAddress> : public LinksLimitReachedExceptionBase
+template<typename...> class LinksLimitReachedException;
+template<typename TLinkAddress> class LinksLimitReachedException<TLinkAddress> : public LinksLimitReachedExceptionBase
+{
+public:
+    LinksLimitReachedException(TLinkAddress limit) : this(FormatMessage(limit))
     {
-        public: LinksLimitReachedException(TLinkAddress limit) : this(FormatMessage(limit)) { }
+    }
 
-        public: LinksLimitReachedException(std::string message, const std::exception& innerException) : LinksLimitReachedExceptionBase(message, innerException) { }
+public:
+    LinksLimitReachedException(std::string message, const std::exception& innerException)
+        : LinksLimitReachedExceptionBase(message, innerException)
+    {
+    }
 
-        public: LinksLimitReachedException(std::string message) : LinksLimitReachedExceptionBase(message) { }
+public:
+    LinksLimitReachedException(std::string message) : LinksLimitReachedExceptionBase(message)
+    {
+    }
 
-        public: LinksLimitReachedException() : LinksLimitReachedExceptionBase(DefaultMessage) { }
+public:
+    LinksLimitReachedException() : LinksLimitReachedExceptionBase(DefaultMessage)
+    {
+    }
 
-        private: static std::string FormatMessage(TLinkAddress limit) { return std::string("Достигнут лимит количества связей в хранилище (").append(Platform::Converters::To<std::string>(limit)).append(")."); }
-    };
-}
+private:
+    static std::string FormatMessage(TLinkAddress limit)
+    {
+        return std::string("Достигнут лимит количества связей в хранилище (")
+            .append(Platform::Converters::To<std::string>(limit))
+            .append(").");
+    }
+};
+} // namespace Platform::Data::Exceptions

--- a/cpp/Platform.Data/Exceptions/LinksLimitReachedExceptionBase.h
+++ b/cpp/Platform.Data/Exceptions/LinksLimitReachedExceptionBase.h
@@ -1,11 +1,19 @@
 ﻿namespace Platform::Data::Exceptions
 {
-    class LinksLimitReachedExceptionBase : public std::exception
+class LinksLimitReachedExceptionBase : public std::exception
+{
+public:
+    inline static std::string DefaultMessage = "Достигнут лимит количества связей в хранилище.";
+
+protected:
+    LinksLimitReachedExceptionBase(std::string message, const std::exception& innerException)
+        : base(message, innerException)
     {
-        public: inline static std::string DefaultMessage = "Достигнут лимит количества связей в хранилище.";
+    }
 
-        protected: LinksLimitReachedExceptionBase(std::string message, const std::exception& innerException) : base(message, innerException) { }
-
-        protected: LinksLimitReachedExceptionBase(std::string message) : base(message) { }
-    };
-}
+protected:
+    LinksLimitReachedExceptionBase(std::string message) : base(message)
+    {
+    }
+};
+} // namespace Platform::Data::Exceptions

--- a/cpp/Platform.Data/Hybrid.h
+++ b/cpp/Platform.Data/Hybrid.h
@@ -1,85 +1,115 @@
 ﻿namespace Platform::Data
 {
-    namespace Internal
+namespace Internal
+{
+constexpr auto smart_to_signed(std::integral auto value) noexcept
+{
+    using raw_type = decltype(value);
+    return static_cast<std::make_signed_t<raw_type>>(value);
+}
+} // namespace Internal
+
+template<std::integral TLinkAddress> class Hybrid
+{
+public:
+    static constexpr TLinkAddress HalfOfNumberValuesRange = std::numeric_limits<TLinkAddress>::max() / 2;
+
+public:
+    static constexpr TLinkAddress ExternalZero = static_cast<TLinkAddress>(HalfOfNumberValuesRange + 1);
+
+public:
+    const TLinkAddress Value = 0;
+
+public:
+    [[nodiscard]] bool IsNothing() const noexcept
     {
-        constexpr auto smart_to_signed(std::integral auto value) noexcept
-        {
-            using raw_type = decltype(value);
-            return static_cast<std::make_signed_t<raw_type>>(value);
-        }
+        return (Value == ExternalZero) || (SignedValue() == 0);
     }
 
-    template<std::integral TLinkAddress>
-    class Hybrid
+public:
+    [[nodiscard]] bool IsInternal() const noexcept
     {
-        public: static constexpr TLinkAddress HalfOfNumberValuesRange = std::numeric_limits<TLinkAddress>::max() / 2;
-        public: static constexpr TLinkAddress ExternalZero = static_cast<TLinkAddress>(HalfOfNumberValuesRange + 1);
+        return SignedValue() > 0;
+    }
 
-        public: const TLinkAddress Value = 0;
+public:
+    [[nodiscard]] bool IsExternal() const noexcept
+    {
+        return (Value == ExternalZero) || (SignedValue() < 0);
+    }
 
-        public: [[nodiscard]] bool IsNothing() const noexcept
+public:
+    [[nodiscard]] auto SignedValue() const noexcept -> decltype(Internal::smart_to_signed(Value))
+    {
+        return Internal::smart_to_signed(Value);
+    }
+
+public:
+    [[nodiscard]] TLinkAddress AbsoluteValue() const noexcept
+    {
+        return (Value == ExternalZero) ? 0 : std::abs(SignedValue());
+    }
+
+public:
+    explicit Hybrid(TLinkAddress value) noexcept : Value(value)
+    {
+    }
+
+public:
+    Hybrid(TLinkAddress value, bool isExternal) noexcept : Value(external_constructor(value, isExternal))
+    {
+    }
+
+public:
+    template<std::integral TOutAddress> explicit operator TOutAddress() const noexcept
+    {
+        return static_cast<TOutAddress>(Value);
+    }
+
+public:
+    explicit operator std::string() const
+    {
+        return IsExternal() ? std::string("<").append(Converters::To<std::string>(AbsoluteValue())).append(1, '>')
+                            : Converters::To<std::string>(Value);
+    }
+
+public:
+    friend std::ostream& operator<<(std::ostream& stream, const Hybrid<TLinkAddress>& self)
+    {
+        return stream << static_cast<std::string>(self);
+    }
+
+public:
+    constexpr auto operator==(const Hybrid<TLinkAddress>& other) const noexcept
+    {
+        return Value == other.Value;
+    }
+
+private:
+    static TLinkAddress external_constructor(TLinkAddress value, bool isExternal) noexcept
+    {
+        if (value == 0 && isExternal)
         {
-            return (Value == ExternalZero) || (SignedValue() == 0);
+            return ExternalZero;
         }
-
-        public: [[nodiscard]] bool IsInternal() const noexcept
+        else
         {
-            return SignedValue() > 0;
+            auto absolute = std::abs(Internal::smart_to_signed(value)); // std::abs is not overloaded for unsigned types
+            return (isExternal) ? -absolute : absolute;
         }
+    }
+};
 
-        public: [[nodiscard]] bool IsExternal() const noexcept
-        {
-            return (Value == ExternalZero) || (SignedValue() < 0);
-        }
-
-        public: [[nodiscard]] auto SignedValue() const noexcept -> decltype(Internal::smart_to_signed(Value))
-        {
-            return Internal::smart_to_signed(Value);
-        }
-
-        public: [[nodiscard]] TLinkAddress AbsoluteValue() const noexcept
-        {
-            return (Value == ExternalZero) ? 0 : std::abs(SignedValue());
-        }
-
-        public: explicit Hybrid(TLinkAddress value) noexcept : Value(value) { }
-
-        public: Hybrid(TLinkAddress value, bool isExternal) noexcept : Value(external_constructor(value, isExternal)) { }
-
-        public: template<std::integral TOutAddress> explicit operator TOutAddress() const noexcept { return static_cast<TOutAddress>(Value); }
-
-        public: explicit operator std::string() const { return IsExternal() ? std::string("<").append(Converters::To<std::string>(AbsoluteValue())).append(1, '>') : Converters::To<std::string>(Value); }
-
-        public: friend std::ostream& operator<<(std::ostream& stream, const Hybrid<TLinkAddress>& self) { return stream << static_cast<std::string>(self); }
-
-        public: constexpr auto operator==(const Hybrid<TLinkAddress>& other) const noexcept { return Value == other.Value; }
-
-        private: static TLinkAddress external_constructor(TLinkAddress value, bool isExternal) noexcept
-        {
-            if (value == 0 && isExternal)
-            {
-                return ExternalZero;
-            }
-            else
-            {
-                auto absolute = std::abs(Internal::smart_to_signed(value)); // std::abs is not overloaded for unsigned types
-                return (isExternal) ? -absolute : absolute;
-            }
-        }
-    };
-
-    template<std::integral TLinkAddress, typename... Args>
-    Hybrid(TLinkAddress, Args...) -> Hybrid<TLinkAddress>;
-}
+template<std::integral TLinkAddress, typename... Args> Hybrid(TLinkAddress, Args...) -> Hybrid<TLinkAddress>;
+} // namespace Platform::Data
 
 namespace std
 {
-    template <typename TLinkAddress>
-    struct hash<Platform::Data::Hybrid<TLinkAddress>>
+template<typename TLinkAddress> struct hash<Platform::Data::Hybrid<TLinkAddress>>
+{
+    std::size_t operator()(auto&& self) const
     {
-        std::size_t operator()(auto&& self) const
-        {
-            return self.Value;
-        }
-    };
-}
+        return self.Value;
+    }
+};
+} // namespace std

--- a/cpp/Platform.Data/ILinks.h
+++ b/cpp/Platform.Data/ILinks.h
@@ -1,25 +1,29 @@
 ﻿namespace Platform::Data
 {
-    using namespace Platform::Interfaces;
-    template<typename TLinksOptions>
-    struct ILinks
-    {
-    public:
-      using LinksOptionsType = TLinksOptions;
-      using LinkAddressType = typename LinksOptionsType::LinkAddressType;
-      static constexpr LinksConstants<LinkAddressType> Constants = LinksOptionsType::Constants;
-      using LinkType = typename LinksOptionsType::LinkType;
-      using ReadHandlerType = typename LinksOptionsType::ReadHandlerType;
-      using WriteHandlerType = typename LinksOptionsType::WriteHandlerType;
+using namespace Platform::Interfaces;
+template<typename TLinksOptions> struct ILinks
+{
+public:
+    using LinksOptionsType = TLinksOptions;
+    using LinkAddressType = typename LinksOptionsType::LinkAddressType;
+    static constexpr LinksConstants<LinkAddressType> Constants = LinksOptionsType::Constants;
+    using LinkType = typename LinksOptionsType::LinkType;
+    using ReadHandlerType = typename LinksOptionsType::ReadHandlerType;
+    using WriteHandlerType = typename LinksOptionsType::WriteHandlerType;
 
-        virtual LinkAddressType Count(const std::vector<LinkAddressType>& restriction) const = 0;
+    virtual LinkAddressType Count(const std::vector<LinkAddressType>& restriction) const = 0;
 
-        virtual LinkAddressType Each(const std::vector<LinkAddressType>& restriction, const ReadHandlerType& handler) const = 0;
+    virtual LinkAddressType Each(const std::vector<LinkAddressType>& restriction,
+                                 const ReadHandlerType& handler) const = 0;
 
-        virtual LinkAddressType Create(const std::vector<LinkAddressType>& substitution, const WriteHandlerType& handler) = 0;
+    virtual LinkAddressType Create(const std::vector<LinkAddressType>& substitution,
+                                   const WriteHandlerType& handler) = 0;
 
-        virtual LinkAddressType Update(const std::vector<LinkAddressType>& restriction, const std::vector<LinkAddressType>& substitution, const WriteHandlerType& handler) = 0;
+    virtual LinkAddressType Update(const std::vector<LinkAddressType>& restriction,
+                                   const std::vector<LinkAddressType>& substitution,
+                                   const WriteHandlerType& handler) = 0;
 
-        virtual LinkAddressType Delete(const std::vector<LinkAddressType>& restriction, const WriteHandlerType& handler) = 0;
-    };
-}
+    virtual LinkAddressType Delete(const std::vector<LinkAddressType>& restriction,
+                                   const WriteHandlerType& handler) = 0;
+};
+} // namespace Platform::Data

--- a/cpp/Platform.Data/ILinksExtensions.h
+++ b/cpp/Platform.Data/ILinksExtensions.h
@@ -1,135 +1,173 @@
 ﻿namespace Platform::Data
 {
-    using namespace Platform::Interfaces;
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Create(TStorage& storage, const typename TStorage::LinkType& substitution)
-    {
-        auto $continue { storage.Constants.Continue };
-        typename TStorage::LinkAddressType createdLinkAddress;
-        DIRECT_METHOD_CALL(TStorage, storage, Create, substitution, [&createdLinkAddress, $continue] (const typename TStorage::LinkType& before, const typename TStorage::LinkType& after)
-        {
-            createdLinkAddress = after[0];
-            return $continue;
-        });
-        return createdLinkAddress;
-    }
-    
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Create(TStorage& storage, std::convertible_to<typename TStorage::LinkAddressType> auto ...substitutionPack)
-    {
-        typename TStorage::LinkType substitution { static_cast<typename TStorage::LinkAddressType>(substitutionPack)... };
-        auto $continue { storage.Constants.Continue };
-        typename TStorage::LinkAddressType createdLinkAddress;
-        DIRECT_METHOD_CALL(TStorage, storage, Create, substitution, [&createdLinkAddress, $continue] (const typename TStorage::LinkType& before, const typename TStorage::LinkType& after)
+using namespace Platform::Interfaces;
+template<typename TStorage>
+static typename TStorage::LinkAddressType Create(TStorage& storage, const typename TStorage::LinkType& substitution)
+{
+    auto $continue{storage.Constants.Continue};
+    typename TStorage::LinkAddressType createdLinkAddress;
+    DIRECT_METHOD_CALL(TStorage,
+                       storage,
+                       Create,
+                       substitution,
+                       [&createdLinkAddress, $continue](const typename TStorage::LinkType& before,
+                                                        const typename TStorage::LinkType& after)
                        {
                            createdLinkAddress = after[0];
                            return $continue;
                        });
-        return createdLinkAddress;
-    }
-    
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Update(TStorage& storage, const typename TStorage::LinkType& restriction, const typename TStorage::LinkType& substitution)
-    {
-        auto $continue{storage.Constants.Continue};
-        typename TStorage::LinkAddressType updatedLinkAddress;
-        DIRECT_METHOD_CALL(TStorage, storage, Update, restriction, substitution, [&updatedLinkAddress, $continue] (const typename TStorage::LinkType& before, const typename TStorage::LinkType& after)
-        {
-            updatedLinkAddress = after[0];
-            return $continue;
-        });
-        return updatedLinkAddress;
-    }
-    
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Delete(TStorage& storage, const typename TStorage::LinkType& restriction)
-    {
-        auto $continue{storage.Constants.Continue};
-        typename TStorage::LinkAddressType deletedLinkAddress;
-        DIRECT_METHOD_CALL(TStorage, storage, Delete, restriction, [&deletedLinkAddress, $continue] (const typename TStorage::LinkType& before, const typename TStorage::LinkType& after)
-        {
-            deletedLinkAddress = before[0];
-            return $continue;
-        });
-        return deletedLinkAddress;
-    }
-    
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Delete(TStorage& storage, typename TStorage::LinkAddressType linkAddress)
-    {
-        auto $continue{storage.Constants.Continue};
-        typename TStorage::LinkAddressType deletedLinkAddress;
-        DIRECT_METHOD_CALL(TStorage, storage, Delete, typename TStorage::LinkType{linkAddress}, [&deletedLinkAddress, $continue] (const typename TStorage::LinkType& before, const typename TStorage::LinkType& after)
-        {
-            deletedLinkAddress = before[0];
-            return $continue;
-        });
-        return deletedLinkAddress;
-    }
-    
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Count(const TStorage& storage, std::convertible_to<typename TStorage::LinkAddressType> auto ...restrictionPack)
-    // TODO: later add noexcept(expr)
-    {
-        typename TStorage::LinkType restriction { static_cast<typename TStorage::LinkAddressType>(restrictionPack)... };
-        return DIRECT_METHOD_CALL(TStorage, storage, Count, restriction);
-    }
-    
-    template<typename TStorage>
-    static bool Exists(const TStorage& storage, typename TStorage::LinkAddressType linkAddress) noexcept
-    {
-        constexpr auto constants = storage.Constants;
-        return IsExternalReference<typename TStorage::LinkAddressType, constants>(linkAddress) || (IsInternalReference<typename TStorage::LinkAddressType, constants>(linkAddress) && DIRECT_METHOD_CALL(TStorage, storage, Count, linkAddress) > 0);
-    }
-    
-    template<typename TStorage>
-    static typename TStorage::LinkAddressType Each(const TStorage& storage, const typename TStorage::ReadHandlerType& handler, std::convertible_to<typename TStorage::LinkAddressType> auto... restriction)
-    // TODO: later create noexcept(expr)
-    {
-        typename TStorage::LinkType restrictionContainer { static_cast<typename TStorage::LinkAddressType>(restriction)... };
-        return DIRECT_METHOD_CALL(TStorage, storage, Each, restrictionContainer, handler);
-    }
+    return createdLinkAddress;
+}
 
-    template<typename TStorage>
-    static typename TStorage::LinkType GetLink(const TStorage& storage, typename TStorage::LinkAddressType linkAddress)
+template<typename TStorage>
+static typename TStorage::LinkAddressType
+Create(TStorage& storage, std::convertible_to<typename TStorage::LinkAddressType> auto... substitutionPack)
+{
+    typename TStorage::LinkType substitution{static_cast<typename TStorage::LinkAddressType>(substitutionPack)...};
+    auto $continue{storage.Constants.Continue};
+    typename TStorage::LinkAddressType createdLinkAddress;
+    DIRECT_METHOD_CALL(TStorage,
+                       storage,
+                       Create,
+                       substitution,
+                       [&createdLinkAddress, $continue](const typename TStorage::LinkType& before,
+                                                        const typename TStorage::LinkType& after)
+                       {
+                           createdLinkAddress = after[0];
+                           return $continue;
+                       });
+    return createdLinkAddress;
+}
+
+template<typename TStorage>
+static typename TStorage::LinkAddressType Update(TStorage& storage,
+                                                 const typename TStorage::LinkType& restriction,
+                                                 const typename TStorage::LinkType& substitution)
+{
+    auto $continue{storage.Constants.Continue};
+    typename TStorage::LinkAddressType updatedLinkAddress;
+    DIRECT_METHOD_CALL(TStorage,
+                       storage,
+                       Update,
+                       restriction,
+                       substitution,
+                       [&updatedLinkAddress, $continue](const typename TStorage::LinkType& before,
+                                                        const typename TStorage::LinkType& after)
+                       {
+                           updatedLinkAddress = after[0];
+                           return $continue;
+                       });
+    return updatedLinkAddress;
+}
+
+template<typename TStorage>
+static typename TStorage::LinkAddressType Delete(TStorage& storage, const typename TStorage::LinkType& restriction)
+{
+    auto $continue{storage.Constants.Continue};
+    typename TStorage::LinkAddressType deletedLinkAddress;
+    DIRECT_METHOD_CALL(TStorage,
+                       storage,
+                       Delete,
+                       restriction,
+                       [&deletedLinkAddress, $continue](const typename TStorage::LinkType& before,
+                                                        const typename TStorage::LinkType& after)
+                       {
+                           deletedLinkAddress = before[0];
+                           return $continue;
+                       });
+    return deletedLinkAddress;
+}
+
+template<typename TStorage>
+static typename TStorage::LinkAddressType Delete(TStorage& storage, typename TStorage::LinkAddressType linkAddress)
+{
+    auto $continue{storage.Constants.Continue};
+    typename TStorage::LinkAddressType deletedLinkAddress;
+    DIRECT_METHOD_CALL(TStorage,
+                       storage,
+                       Delete,
+                       typename TStorage::LinkType{linkAddress},
+                       [&deletedLinkAddress, $continue](const typename TStorage::LinkType& before,
+                                                        const typename TStorage::LinkType& after)
+                       {
+                           deletedLinkAddress = before[0];
+                           return $continue;
+                       });
+    return deletedLinkAddress;
+}
+
+template<typename TStorage>
+static typename TStorage::LinkAddressType
+Count(const TStorage& storage, std::convertible_to<typename TStorage::LinkAddressType> auto... restrictionPack)
+// TODO: later add noexcept(expr)
+{
+    typename TStorage::LinkType restriction{static_cast<typename TStorage::LinkAddressType>(restrictionPack)...};
+    return DIRECT_METHOD_CALL(TStorage, storage, Count, restriction);
+}
+
+template<typename TStorage>
+static bool Exists(const TStorage& storage, typename TStorage::LinkAddressType linkAddress) noexcept
+{
+    constexpr auto constants = storage.Constants;
+    return IsExternalReference<typename TStorage::LinkAddressType, constants>(linkAddress) ||
+           (IsInternalReference<typename TStorage::LinkAddressType, constants>(linkAddress) &&
+            DIRECT_METHOD_CALL(TStorage, storage, Count, linkAddress) > 0);
+}
+
+template<typename TStorage>
+static typename TStorage::LinkAddressType
+Each(const TStorage& storage,
+     const typename TStorage::ReadHandlerType& handler,
+     std::convertible_to<typename TStorage::LinkAddressType> auto... restriction)
+// TODO: later create noexcept(expr)
+{
+    typename TStorage::LinkType restrictionContainer{static_cast<typename TStorage::LinkAddressType>(restriction)...};
+    return DIRECT_METHOD_CALL(TStorage, storage, Each, restrictionContainer, handler);
+}
+
+template<typename TStorage>
+static typename TStorage::LinkType GetLink(const TStorage& storage, typename TStorage::LinkAddressType linkAddress)
+{
+    constexpr auto constants = storage.Constants;
+    auto $continue = constants.Continue;
+    auto any = constants.Any;
+    if (IsExternalReference<typename TStorage::LinkAddressType, constants>(linkAddress))
     {
-        constexpr auto constants = storage.Constants;
-        auto $continue = constants.Continue;
-        auto any = constants.Any;
-        if (IsExternalReference<typename TStorage::LinkAddressType, constants>(linkAddress))
-        {
-            typename TStorage::LinkType resultLink {linkAddress, linkAddress, linkAddress};
-            return resultLink;
-        }
-        typename TStorage::LinkType resultLink;
-        DIRECT_METHOD_CALL(TStorage, storage, Each, typename TStorage::LinkType{linkAddress}, [&resultLink, $continue](const typename TStorage::LinkType& link)
-        {
-            resultLink = link;
-            return $continue;
-        });
-        Ensures(!resultLink.empty());
+        typename TStorage::LinkType resultLink{linkAddress, linkAddress, linkAddress};
         return resultLink;
     }
-
-    template<typename TStorage>
-    static bool IsFullPoint(TStorage& storage, typename TStorage::LinkAddressType link)
-    {
-        if (IsExternalReference(storage.Constants, link))
-        {
-            return true;
-        }
-        Ensures(DIRECT_METHOD_CALL(TStorage, storage, Exists, link));
-        return Point<typename TStorage::LinkAddressType>::IsFullPoint(DIRECT_METHOD_CALL(TStorage, storage, GetLink, link));
-    }
-
-    template<typename TStorage>
-    static bool IsPartialPoint(TStorage& storage, typename TStorage::LinkAddressType link)
-    {
-        if (IsExternalReference(storage.Constants, link))
-        {
-            return true;
-        }
-        Ensures(DIRECT_METHOD_CALL(TStorage, storage, Exists, link));
-        return Point<typename TStorage::LinkAddressType>::IsPartialPoint(DIRECT_METHOD_CALL(TStorage, storage, GetLink, link));
-    }
+    typename TStorage::LinkType resultLink;
+    DIRECT_METHOD_CALL(TStorage,
+                       storage,
+                       Each,
+                       typename TStorage::LinkType{linkAddress},
+                       [&resultLink, $continue](const typename TStorage::LinkType& link)
+                       {
+                           resultLink = link;
+                           return $continue;
+                       });
+    Ensures(!resultLink.empty());
+    return resultLink;
 }
+
+template<typename TStorage> static bool IsFullPoint(TStorage& storage, typename TStorage::LinkAddressType link)
+{
+    if (IsExternalReference(storage.Constants, link))
+    {
+        return true;
+    }
+    Ensures(DIRECT_METHOD_CALL(TStorage, storage, Exists, link));
+    return Point<typename TStorage::LinkAddressType>::IsFullPoint(DIRECT_METHOD_CALL(TStorage, storage, GetLink, link));
+}
+
+template<typename TStorage> static bool IsPartialPoint(TStorage& storage, typename TStorage::LinkAddressType link)
+{
+    if (IsExternalReference(storage.Constants, link))
+    {
+        return true;
+    }
+    Ensures(DIRECT_METHOD_CALL(TStorage, storage, Exists, link));
+    return Point<typename TStorage::LinkAddressType>::IsPartialPoint(
+        DIRECT_METHOD_CALL(TStorage, storage, GetLink, link));
+}
+} // namespace Platform::Data

--- a/cpp/Platform.Data/ISynchronizedLinks.h
+++ b/cpp/Platform.Data/ISynchronizedLinks.h
@@ -1,11 +1,14 @@
 ﻿namespace Platform::Data
 {
-    // TODO: rework Platform.Threading
-    template <typename ...> class ISynchronizedLinks;
-    template <typename TLinkAddress, typename TLinks, typename TConstants> class ISynchronizedLinks<TLinkAddress, TLinks, TConstants> : public ISynchronized<TLinks>, ILinks<TLinkAddress, TConstants>
-        where TLinks : ILinks<TLinkAddress, TConstants>
-        where TConstants : LinksConstants<TLinkAddress>
-    {
-    public:
-    }
+// TODO: rework Platform.Threading
+template<typename...> class ISynchronizedLinks;
+template<typename TLinkAddress, typename TLinks, typename TConstants>
+class ISynchronizedLinks<TLinkAddress, TLinks, TConstants> : public ISynchronized<TLinks>,
+                                                             ILinks<TLinkAddress, TConstants>
+                                                                 where TLinks : ILinks<TLinkAddress, TConstants>
+                                                                                    where TConstants
+    : LinksConstants<TLinkAddress>
+{
+public:
 }
+} // namespace Platform::Data

--- a/cpp/Platform.Data/LinkAddress.h
+++ b/cpp/Platform.Data/LinkAddress.h
@@ -1,77 +1,88 @@
 ﻿namespace Platform::Data
 {
-    template <std::integral TLinkAddress>
-    class LinkAddress
+template<std::integral TLinkAddress> class LinkAddress
+{
+public:
+    const TLinkAddress Index;
+
+public:
+    auto operator[](std::integral auto index) const -> const TLinkAddress&
     {
-        public: const TLinkAddress Index;
-
-        public: auto operator[](std::integral auto index) const -> const TLinkAddress&
-        {
-            if (index == 0)
-            {
-                return Index;
-            }
-            else
-            {
-                throw std::out_of_range{""};
-            }
-        }
-
-        public: [[nodiscard]] constexpr auto size() const noexcept -> std::size_t
-        {
-            return 1;
-        }
-
-        public: explicit LinkAddress(TLinkAddress index)
-            : Index(index)
-        {
-        }
-
-        public: template<typename OtherTLinkAddress> explicit LinkAddress(const LinkAddress<OtherTLinkAddress>& linkAddress)
-            : Index(linkAddress.Index)
-        {
-        }
-
-        public: [[nodiscard]] auto begin() const noexcept -> const TLinkAddress*
-        {
-            return std::addressof(Index);
-        }
-
-        public: [[nodiscard]] auto end() const noexcept -> const TLinkAddress*
-        {
-            // TODO: maybe explicit write "+ 1" instead
-            return std::addressof(Index) + size();
-        }
-
-        public: auto operator==(LinkAddress<TLinkAddress> other) const noexcept
-        {
-            return Index == other.Index;
-        }
-
-        public: explicit operator TLinkAddress() const noexcept
+        if (index == 0)
         {
             return Index;
         }
-
-    public: operator std::vector<TLinkAddress>() const
+        else
         {
-            return std::vector<TLinkAddress>{Index};
+            throw std::out_of_range{""};
         }
+    }
 
-        public: explicit operator std::string() const { return Converters::To<std::string>(Index); }
+public:
+    [[nodiscard]] constexpr auto size() const noexcept -> std::size_t
+    {
+        return 1;
+    }
 
-        public: friend std::ostream& operator<<(std::ostream& stream, LinkAddress<TLinkAddress> self)
-        {
-            return stream << static_cast<std::string>(self);
-        }
-    };
+public:
+    explicit LinkAddress(TLinkAddress index) : Index(index)
+    {
+    }
 
-    template<typename TLinkAddress>
-    LinkAddress(TLinkAddress) -> LinkAddress<TLinkAddress>;
-}
+public:
+    template<typename OtherTLinkAddress>
+    explicit LinkAddress(const LinkAddress<OtherTLinkAddress>& linkAddress) : Index(linkAddress.Index)
+    {
+    }
 
-template<typename TLinkAddress>
-struct std::hash<Platform::Data::LinkAddress<TLinkAddress>>
+public:
+    [[nodiscard]] auto begin() const noexcept -> const TLinkAddress*
+    {
+        return std::addressof(Index);
+    }
+
+public:
+    [[nodiscard]] auto end() const noexcept -> const TLinkAddress*
+    {
+        // TODO: maybe explicit write "+ 1" instead
+        return std::addressof(Index) + size();
+    }
+
+public:
+    auto operator==(LinkAddress<TLinkAddress> other) const noexcept
+    {
+        return Index == other.Index;
+    }
+
+public:
+    explicit operator TLinkAddress() const noexcept
+    {
+        return Index;
+    }
+
+public:
+    operator std::vector<TLinkAddress>() const
+    {
+        return std::vector<TLinkAddress>{Index};
+    }
+
+public:
+    explicit operator std::string() const
+    {
+        return Converters::To<std::string>(Index);
+    }
+
+public:
+    friend std::ostream& operator<<(std::ostream& stream, LinkAddress<TLinkAddress> self)
+    {
+        return stream << static_cast<std::string>(self);
+    }
+};
+
+template<typename TLinkAddress> LinkAddress(TLinkAddress) -> LinkAddress<TLinkAddress>;
+} // namespace Platform::Data
+
+template<typename TLinkAddress> struct std::hash<Platform::Data::LinkAddress<TLinkAddress>>
 {
     std::size_t operator()(auto&& self) const
     {

--- a/cpp/Platform.Data/LinksConstants.h
+++ b/cpp/Platform.Data/LinksConstants.h
@@ -1,127 +1,131 @@
 ﻿namespace Platform::Data
 {
-    template<std::integral TLinkAddress>
-    struct LinksConstants
+template<std::integral TLinkAddress> struct LinksConstants
+{
+    static constexpr int DefaultTargetPart = 2;
+
+public:
+    const TLinkAddress IndexPart{};
+
+public:
+    const TLinkAddress SourcePart{};
+
+public:
+    const TLinkAddress TargetPart{};
+
+public:
+    const TLinkAddress Continue{};
+
+public:
+    const TLinkAddress Break{};
+
+public:
+    const TLinkAddress Skip{};
+
+public:
+    const TLinkAddress Null{};
+
+public:
+    const TLinkAddress Any{};
+
+public:
+    const TLinkAddress Itself{};
+
+public:
+    const TLinkAddress Error{};
+
+public:
+    const Ranges::Range<TLinkAddress> InternalReferencesRange{};
+
+public:
+    const Ranges::Range<TLinkAddress> ExternalReferencesRange = std::nullopt;
+    const bool IsExternalReferencesRangeEnabled;
+
+public:
+    constexpr LinksConstants(TLinkAddress targetPart,
+                             const Ranges::Range<TLinkAddress>& possibleInternalReferencesRange,
+                             Ranges::Range<TLinkAddress> possibleExternalReferencesRange) noexcept
+        : IndexPart(0), SourcePart(1), TargetPart(targetPart), Continue(possibleInternalReferencesRange.Maximum),
+          Break(possibleInternalReferencesRange.Maximum - 1), Skip(possibleInternalReferencesRange.Maximum - 2),
+          Null(TLinkAddress{}), Any(possibleInternalReferencesRange.Maximum - 3),
+          Itself(possibleInternalReferencesRange.Maximum - 4), Error(possibleInternalReferencesRange.Maximum - 5),
+          InternalReferencesRange(
+              Ranges::Range{possibleInternalReferencesRange.Minimum,
+                            static_cast<TLinkAddress>(possibleInternalReferencesRange.Maximum - 6)}),
+          ExternalReferencesRange(possibleExternalReferencesRange),
+          IsExternalReferencesRangeEnabled(possibleExternalReferencesRange.Minimum !=
+                                           possibleExternalReferencesRange.Maximum)
     {
-        static constexpr int DefaultTargetPart = 2;
-    public:
-        const TLinkAddress IndexPart{};
+    }
 
-    public:
-        const TLinkAddress SourcePart{};
+public:
+    constexpr explicit LinksConstants(TLinkAddress targetPart, bool enableExternalReferencesSupport) noexcept
+        : LinksConstants(targetPart,
+                         GetDefaultInternalReferencesRange(enableExternalReferencesSupport),
+                         GetDefaultExternalReferencesRange(enableExternalReferencesSupport))
+    {
+    }
 
-    public:
-        const TLinkAddress TargetPart{};
+public:
+    constexpr explicit LinksConstants(Ranges::Range<TLinkAddress> possibleInternalReferencesRange,
+                                      Ranges::Range<TLinkAddress> possibleExternalReferencesRange) noexcept
+        : LinksConstants(DefaultTargetPart, possibleInternalReferencesRange, possibleExternalReferencesRange)
+    {
+    }
 
-    public:
-        const TLinkAddress Continue{};
+public:
+    constexpr explicit LinksConstants(bool enableExternalReferencesSupport) noexcept
+        : LinksConstants(GetDefaultInternalReferencesRange(enableExternalReferencesSupport),
+                         GetDefaultExternalReferencesRange(enableExternalReferencesSupport))
+    {
+    }
 
-    public:
-        const TLinkAddress Break{};
+public:
+    constexpr explicit LinksConstants(TLinkAddress targetPart,
+                                      Ranges::Range<TLinkAddress> possibleInternalReferencesRange) noexcept
+        : LinksConstants(targetPart, possibleInternalReferencesRange, std::nullopt)
+    {
+    }
 
-    public:
-        const TLinkAddress Skip{};
+public:
+    constexpr explicit LinksConstants(Ranges::Range<TLinkAddress> possibleInternalReferencesRange) noexcept
+        : LinksConstants(DefaultTargetPart, possibleInternalReferencesRange, std::nullopt)
+    {
+    }
 
-    public:
-        const TLinkAddress Null{};
+public:
+    constexpr explicit LinksConstants() noexcept : LinksConstants(DefaultTargetPart, false)
+    {
+    }
 
-    public:
-        const TLinkAddress Any{};
+public:
+    static constexpr Ranges::Range<TLinkAddress>
+    GetDefaultInternalReferencesRange(bool enableExternalReferencesSupport) noexcept
+    {
+        using namespace Ranges;
 
-    public:
-        const TLinkAddress Itself{};
-
-    public:
-        const TLinkAddress Error{};
-
-    public:
-        const Ranges::Range<TLinkAddress> InternalReferencesRange{};
-
-    public:
-         const Ranges::Range<TLinkAddress> ExternalReferencesRange = std::nullopt;
-         const bool IsExternalReferencesRangeEnabled;
-
-    public:
-        constexpr LinksConstants(TLinkAddress targetPart, const Ranges::Range<TLinkAddress>& possibleInternalReferencesRange, Ranges::Range<TLinkAddress> possibleExternalReferencesRange) noexcept
-            :
-            IndexPart(0),
-            SourcePart(1),
-            TargetPart(targetPart),
-            Continue(possibleInternalReferencesRange.Maximum),
-            Break(possibleInternalReferencesRange.Maximum - 1),
-            Skip(possibleInternalReferencesRange.Maximum - 2),
-            Null(TLinkAddress{}),
-            Any(possibleInternalReferencesRange.Maximum - 3),
-            Itself(possibleInternalReferencesRange.Maximum - 4),
-            Error(possibleInternalReferencesRange.Maximum - 5),
-            InternalReferencesRange(Ranges::Range{possibleInternalReferencesRange.Minimum, static_cast<TLinkAddress>(possibleInternalReferencesRange.Maximum - 6)}),
-            ExternalReferencesRange(possibleExternalReferencesRange),
-            IsExternalReferencesRangeEnabled(possibleExternalReferencesRange.Minimum != possibleExternalReferencesRange.Maximum)
+        if (enableExternalReferencesSupport)
         {
+            return Range{1, static_cast<TLinkAddress>(Hybrid<TLinkAddress>::HalfOfNumberValuesRange)};
         }
-
-    public:
-        constexpr explicit LinksConstants(TLinkAddress targetPart, bool enableExternalReferencesSupport) noexcept :
-            LinksConstants(targetPart, GetDefaultInternalReferencesRange(enableExternalReferencesSupport), GetDefaultExternalReferencesRange(enableExternalReferencesSupport))
+        else
         {
+            return Range{1, std::numeric_limits<TLinkAddress>::max()};
         }
+    }
 
-    public:
-        constexpr explicit LinksConstants(Ranges::Range<TLinkAddress> possibleInternalReferencesRange, Ranges::Range<TLinkAddress> possibleExternalReferencesRange) noexcept :
-            LinksConstants(DefaultTargetPart, possibleInternalReferencesRange, possibleExternalReferencesRange)
+public:
+    static constexpr auto
+    GetDefaultExternalReferencesRange(bool enableExternalReferencesSupport) noexcept -> Ranges::Range<TLinkAddress>
+    {
+        if (enableExternalReferencesSupport)
         {
+            return Ranges::Range{Hybrid<TLinkAddress>::ExternalZero, std::numeric_limits<TLinkAddress>::max()};
         }
-
-    public:
-        constexpr explicit LinksConstants(bool enableExternalReferencesSupport) noexcept :
-            LinksConstants(GetDefaultInternalReferencesRange(enableExternalReferencesSupport), GetDefaultExternalReferencesRange(enableExternalReferencesSupport))
+        else
         {
+            return Ranges::Range<TLinkAddress>{0};
         }
-
-    public:
-        constexpr explicit LinksConstants(TLinkAddress targetPart, Ranges::Range<TLinkAddress> possibleInternalReferencesRange) noexcept :
-            LinksConstants(targetPart, possibleInternalReferencesRange, std::nullopt)
-        {
-        }
-
-    public:
-        constexpr explicit LinksConstants(Ranges::Range<TLinkAddress> possibleInternalReferencesRange) noexcept :
-            LinksConstants(DefaultTargetPart, possibleInternalReferencesRange, std::nullopt)
-        {
-        }
-
-    public:
-        constexpr explicit LinksConstants() noexcept :
-            LinksConstants(DefaultTargetPart, false)
-        {
-        }
-
-    public:
-        static constexpr Ranges::Range<TLinkAddress> GetDefaultInternalReferencesRange(bool enableExternalReferencesSupport) noexcept
-        {
-            using namespace Ranges;
-
-            if (enableExternalReferencesSupport)
-            {
-                return Range{1, static_cast<TLinkAddress>(Hybrid<TLinkAddress>::HalfOfNumberValuesRange)};
-            }
-            else
-            {
-                return Range{1, std::numeric_limits<TLinkAddress>::max()};
-            }
-        }
-
-    public:
-        static constexpr auto GetDefaultExternalReferencesRange(bool enableExternalReferencesSupport) noexcept -> Ranges::Range<TLinkAddress>
-        {
-            if (enableExternalReferencesSupport)
-            {
-                return Ranges::Range{Hybrid<TLinkAddress>::ExternalZero, std::numeric_limits<TLinkAddress>::max()};
-            }
-            else
-            {
-                return Ranges::Range<TLinkAddress>{0};
-            }
-        }
-    };
-}// namespace Platform::Data
+    }
+};
+} // namespace Platform::Data

--- a/cpp/Platform.Data/LinksConstantsExtensions.h
+++ b/cpp/Platform.Data/LinksConstantsExtensions.h
@@ -1,21 +1,21 @@
 ﻿namespace Platform::Data
 {
-    template <typename TLinkAddress, LinksConstants<TLinkAddress> VLinksConstants>
-    static bool IsInternalReference(TLinkAddress linkAddress) noexcept
-    {
-        return VLinksConstants.InternalReferencesRange.Contains(linkAddress);
-    }
-
-    template <typename TLinkAddress, LinksConstants<TLinkAddress> VLinksConstants>
-    static bool IsReference(TLinkAddress linkAddress) noexcept
-    {
-        return IsInternalReference(VLinksConstants, linkAddress) || IsExternalReference(VLinksConstants, linkAddress);
-    }
-
-    template <typename TLinkAddress, LinksConstants<TLinkAddress> VLinksConstants>
-    static bool IsExternalReference(TLinkAddress linkAddress) noexcept
-    {
-        auto&& range = VLinksConstants.ExternalReferencesRange;
-        return range.Contains(linkAddress);
-    }
+template<typename TLinkAddress, LinksConstants<TLinkAddress> VLinksConstants>
+static bool IsInternalReference(TLinkAddress linkAddress) noexcept
+{
+    return VLinksConstants.InternalReferencesRange.Contains(linkAddress);
 }
+
+template<typename TLinkAddress, LinksConstants<TLinkAddress> VLinksConstants>
+static bool IsReference(TLinkAddress linkAddress) noexcept
+{
+    return IsInternalReference(VLinksConstants, linkAddress) || IsExternalReference(VLinksConstants, linkAddress);
+}
+
+template<typename TLinkAddress, LinksConstants<TLinkAddress> VLinksConstants>
+static bool IsExternalReference(TLinkAddress linkAddress) noexcept
+{
+    auto&& range = VLinksConstants.ExternalReferencesRange;
+    return range.Contains(linkAddress);
+}
+} // namespace Platform::Data

--- a/cpp/Platform.Data/LinksOptions.h
+++ b/cpp/Platform.Data/LinksOptions.h
@@ -1,21 +1,25 @@
 namespace Platform::Data
 {
 
-    template<std::integral TLinkAddress = std::uint64_t, LinksConstants<TLinkAddress> VConstants = LinksConstants<TLinkAddress>{true}, typename TLink = std::vector<TLinkAddress>, typename TReadHandler = std::function<TLinkAddress(TLink)>, typename TWriteHandler = std::function<TLinkAddress(TLink, TLink)>>
-    struct LinksOptions
-    {
-        using LinkAddressType = TLinkAddress;
-        using LinkType = TLink;
-        using ReadHandlerType = TReadHandler;
-        using WriteHandlerType = TWriteHandler;
-        static constexpr LinksConstants<LinkAddressType> Constants = VConstants;
-    };
+template<std::integral TLinkAddress = std::uint64_t,
+         LinksConstants<TLinkAddress> VConstants = LinksConstants<TLinkAddress>{true},
+         typename TLink = std::vector<TLinkAddress>,
+         typename TReadHandler = std::function<TLinkAddress(TLink)>,
+         typename TWriteHandler = std::function<TLinkAddress(TLink, TLink)>>
+struct LinksOptions
+{
+    using LinkAddressType = TLinkAddress;
+    using LinkType = TLink;
+    using ReadHandlerType = TReadHandler;
+    using WriteHandlerType = TWriteHandler;
+    static constexpr LinksConstants<LinkAddressType> Constants = VConstants;
+};
 
 //    template<typename ...>
 //    struct LinksOptions;
 //
-//    template<typename TLinkAddress, LinksConstants<TLinkAddress> VConstants, typename TLink, typename TWriteHandler, typename TReadHandler>
-//    struct LinksOptions<TLinkAddress, VConstants, TLink, TWriteHandler, TReadHandler>
+//    template<typename TLinkAddress, LinksConstants<TLinkAddress> VConstants, typename TLink, typename TWriteHandler,
+//    typename TReadHandler> struct LinksOptions<TLinkAddress, VConstants, TLink, TWriteHandler, TReadHandler>
 //    {
 //        using LinkAddressType = TLinkAddress;
 //        using LinkType = std::vector<LinkAddressType>;
@@ -26,14 +30,16 @@ namespace Platform::Data
 //
 //
 //    template<typename TLinkAddress, LinksConstants<TLinkAddress> VConstants, typename TLink, typename TWriteHandler>
-//    struct LinksOptions<TLinkAddress, VConstants, TLink, TWriteHandler> : LinksOptions<TLinkAddress, VConstants, TLink, TWriteHandler, std::function<TLinkAddress(TLink)>>
+//    struct LinksOptions<TLinkAddress, VConstants, TLink, TWriteHandler> : LinksOptions<TLinkAddress, VConstants,
+//    TLink, TWriteHandler, std::function<TLinkAddress(TLink)>>
 //    {
 //
 //    };
 //
 //
 //    template<typename TLinkAddress, LinksConstants<TLinkAddress> VConstants, typename TLink>
-//    struct LinksOptions<TLinkAddress, VConstants, TLink> : LinksOptions<TLinkAddress, VConstants, TLink, std::function<TLinkAddress(TLink, TLink)>>
+//    struct LinksOptions<TLinkAddress, VConstants, TLink> : LinksOptions<TLinkAddress, VConstants, TLink,
+//    std::function<TLinkAddress(TLink, TLink)>>
 //    {
 //
 //    };
@@ -55,5 +61,4 @@ namespace Platform::Data
 //
 //    };
 
-
-}
+} // namespace Platform::Data

--- a/cpp/Platform.Data/Numbers/Raw/AddressToRawNumberConverter.h
+++ b/cpp/Platform.Data/Numbers/Raw/AddressToRawNumberConverter.h
@@ -1,7 +1,11 @@
 ﻿namespace Platform::Data::Numbers::Raw
 {
-    template<std::integral TLink> class AddressToRawNumberConverter
+template<std::integral TLink> class AddressToRawNumberConverter
+{
+public:
+    TLink operator()(TLink source) const noexcept
     {
-        public: TLink operator()(TLink source) const noexcept { return static_cast<TLink>(Hybrid<TLink>(source, true)); }
-    };
-}
+        return static_cast<TLink>(Hybrid<TLink>(source, true));
+    }
+};
+} // namespace Platform::Data::Numbers::Raw

--- a/cpp/Platform.Data/Numbers/Raw/RawNumberToAddressConverter.h
+++ b/cpp/Platform.Data/Numbers/Raw/RawNumberToAddressConverter.h
@@ -1,8 +1,12 @@
 ﻿namespace Platform::Data::Numbers::Raw
 {
-    template<std::integral TLink> class RawNumberToAddressConverter
+template<std::integral TLink> class RawNumberToAddressConverter
+{
+    // TODO: maybe use C++ functor style? [std::hash and other]
+public:
+    TLink operator()(TLink source) const noexcept
     {
-        // TODO: maybe use C++ functor style? [std::hash and other]
-        public: TLink operator()(TLink source) const noexcept { return Hybrid<TLink>(source).AbsoluteValue(); }
-    };
-}
+        return Hybrid<TLink>(source).AbsoluteValue();
+    }
+};
+} // namespace Platform::Data::Numbers::Raw

--- a/cpp/Platform.Data/Platform.Data.h
+++ b/cpp/Platform.Data/Platform.Data.h
@@ -1,20 +1,20 @@
 #pragma once
 
+#include <Platform.Interfaces.h>
 #include <Platform.Ranges.h>
 #include <Platform.Setters.h>
-#include <Platform.Interfaces.h>
 
 #include "WriteHandlerState.h"
 
 #include "Numbers/Raw/AddressToRawNumberConverter.h"
 #include "Numbers/Raw/RawNumberToAddressConverter.h"
 
-#include "LinkAddress.h"
-#include "Point.h"
 #include "Hybrid.h"
-#include "LinksConstants.h"
-#include "LinksOptions.h"
-#include "LinksConstantsExtensions.h"
 #include "ILinks.h"
+#include "LinkAddress.h"
+#include "LinksConstants.h"
+#include "LinksConstantsExtensions.h"
+#include "LinksOptions.h"
+#include "Point.h"
 
 #include "ILinksExtensions.h"

--- a/cpp/Platform.Data/Point.h
+++ b/cpp/Platform.Data/Point.h
@@ -2,118 +2,135 @@
 
 namespace Platform::Data
 {
-    namespace Internal
-    {
-        auto gen_always_index(auto index)
-        {
-            return [index](auto) { return index; };
-        }
-
-        template<typename TLinkAddress>
-        using PointBase = decltype(std::views::iota(std::size_t{}, std::size_t{}) | std::views::transform(Internal::gen_always_index(TLinkAddress{})));
-    }
-
-    template <std::integral TLinkAddress>
-    class Point : public Internal::PointBase<TLinkAddress>
-    {
-        using base = Internal::PointBase<TLinkAddress>;
-
-        // TODO: maybe remove or convert to property
-        public: const TLinkAddress Index;
-
-        // TODO: maybe remove or convert to property
-        public: const std::size_t Size;
-
-        public: auto operator[](std::size_t index) const -> TLinkAddress
-        {
-            if (index < Size)
-            {
-                return Index;
-            }
-            else
-            {
-                throw std::out_of_range{""};
-            }
-        }
-
-        public: Point(TLinkAddress index, std::size_t size) :
-            Index(index), Size(size), base(std::views::iota(std::size_t(0), size), Internal::gen_always_index(index))
-        {
-        }
-
-        public: auto operator==(const LinkAddress<TLinkAddress> &other) const noexcept
-        {
-            return Index == other.Index;
-        }
-
-        public: explicit operator TLinkAddress() const noexcept { return Index; }
-
-        public: explicit operator std::string() const { return Converters::To<std::string>(Index).data(); }
-
-        public: friend std::ostream& operator<<(std::ostream& stream, const Point<TLinkAddress>& self) { return stream << static_cast<std::string>(self); }
-    };
-
-    template<std::integral TLinkAddress, typename... Args>
-    Point(TLinkAddress, Args...) -> Point<TLinkAddress>;
-
-    static bool IsFullPointUnchecked(Interfaces::CEnumerable auto&& link)
-    requires std::integral<typename Interfaces::Enumerable<decltype(link)>::Item>
-    {
-        auto iter = std::ranges::begin(link);
-        auto end = std::ranges::end(link);
-        return std::ranges::all_of(iter + 1, end, [&iter](auto&& item) {return item == *iter; });
-    }
-
-    static bool IsFullPoint(Interfaces::CEnumerable auto&& link)
-    requires std::integral<typename Interfaces::Enumerable<decltype(link)>::Item>
-    {
-        using namespace Ranges;
-        constexpr auto link_range = Range{2, std::numeric_limits<std::int32_t>::max()};
-
-        Platform::Ranges::Ensure::Always::ArgumentInRange(std::ranges::size(link), link_range, "link", "Cannot determine link's pointness using only its identifier.");
-        return IsFullPointUnchecked(link);
-    }
-
-    static bool IsFullPoint(std::integral auto... params)
-    {
-        std::common_type_t<decltype(params)...> link[] = { params... };
-        return IsFullPoint(link);
-    }
-
-    static bool IsPartialPointUnchecked(Interfaces::CEnumerable auto&& link)
-    requires std::integral<typename Interfaces::Enumerable<decltype(link)>::Item>
-    {
-        auto iter = std::ranges::begin(link);
-        auto end = std::ranges::end(link);
-
-        return std::ranges::any_of(iter + 1, end, [&iter](auto&& item) { return item == *iter; });
-    }
-
-    static bool IsPartialPoint(Interfaces::CEnumerable auto&& link)
-    {
-        using namespace Platform::Ranges;
-
-        // TODO: after my PR
-        Ensure::Always::ArgumentInRange(std::ranges::size(link) , Range{2, std::numeric_limits<std::int32_t>::max()}, "link", "Cannot determine link's pointness using only its identifier.");
-        return IsPartialPointUnchecked(link);
-    }
-
-    // TODO: we don't have args... to array-like converter
-    static bool IsPartialPoint(std::integral auto... params)
-    {
-        std::common_type_t<decltype(params)...> link[] = { params... };
-        static_assert(Interfaces::CEnumerable<decltype(link)>);
-        return IsPartialPoint(link);
-    }
+namespace Internal
+{
+auto gen_always_index(auto index)
+{
+    return [index](auto) { return index; };
 }
 
+template<typename TLinkAddress>
+using PointBase = decltype(std::views::iota(std::size_t{}, std::size_t{}) |
+                           std::views::transform(Internal::gen_always_index(TLinkAddress{})));
+} // namespace Internal
 
-template <typename TLinkAddress>
-struct std::hash<Platform::Data::Point<TLinkAddress>>
+template<std::integral TLinkAddress> class Point : public Internal::PointBase<TLinkAddress>
+{
+    using base = Internal::PointBase<TLinkAddress>;
+
+    // TODO: maybe remove or convert to property
+public:
+    const TLinkAddress Index;
+
+    // TODO: maybe remove or convert to property
+public:
+    const std::size_t Size;
+
+public:
+    auto operator[](std::size_t index) const -> TLinkAddress
+    {
+        if (index < Size)
+        {
+            return Index;
+        }
+        else
+        {
+            throw std::out_of_range{""};
+        }
+    }
+
+public:
+    Point(TLinkAddress index, std::size_t size)
+        : Index(index), Size(size), base(std::views::iota(std::size_t(0), size), Internal::gen_always_index(index))
+    {
+    }
+
+public:
+    auto operator==(const LinkAddress<TLinkAddress>& other) const noexcept
+    {
+        return Index == other.Index;
+    }
+
+public:
+    explicit operator TLinkAddress() const noexcept
+    {
+        return Index;
+    }
+
+public:
+    explicit operator std::string() const
+    {
+        return Converters::To<std::string>(Index).data();
+    }
+
+public:
+    friend std::ostream& operator<<(std::ostream& stream, const Point<TLinkAddress>& self)
+    {
+        return stream << static_cast<std::string>(self);
+    }
+};
+
+template<std::integral TLinkAddress, typename... Args> Point(TLinkAddress, Args...) -> Point<TLinkAddress>;
+
+static bool IsFullPointUnchecked(Interfaces::CEnumerable auto&& link)
+    requires std::integral<typename Interfaces::Enumerable<decltype(link)>::Item>
+{
+    auto iter = std::ranges::begin(link);
+    auto end = std::ranges::end(link);
+    return std::ranges::all_of(iter + 1, end, [&iter](auto&& item) { return item == *iter; });
+}
+
+static bool IsFullPoint(Interfaces::CEnumerable auto&& link)
+    requires std::integral<typename Interfaces::Enumerable<decltype(link)>::Item>
+{
+    using namespace Ranges;
+    constexpr auto link_range = Range{2, std::numeric_limits<std::int32_t>::max()};
+
+    Platform::Ranges::Ensure::Always::ArgumentInRange(
+        std::ranges::size(link), link_range, "link", "Cannot determine link's pointness using only its identifier.");
+    return IsFullPointUnchecked(link);
+}
+
+static bool IsFullPoint(std::integral auto... params)
+{
+    std::common_type_t<decltype(params)...> link[] = {params...};
+    return IsFullPoint(link);
+}
+
+static bool IsPartialPointUnchecked(Interfaces::CEnumerable auto&& link)
+    requires std::integral<typename Interfaces::Enumerable<decltype(link)>::Item>
+{
+    auto iter = std::ranges::begin(link);
+    auto end = std::ranges::end(link);
+
+    return std::ranges::any_of(iter + 1, end, [&iter](auto&& item) { return item == *iter; });
+}
+
+static bool IsPartialPoint(Interfaces::CEnumerable auto&& link)
+{
+    using namespace Platform::Ranges;
+
+    // TODO: after my PR
+    Ensure::Always::ArgumentInRange(std::ranges::size(link),
+                                    Range{2, std::numeric_limits<std::int32_t>::max()},
+                                    "link",
+                                    "Cannot determine link's pointness using only its identifier.");
+    return IsPartialPointUnchecked(link);
+}
+
+// TODO: we don't have args... to array-like converter
+static bool IsPartialPoint(std::integral auto... params)
+{
+    std::common_type_t<decltype(params)...> link[] = {params...};
+    static_assert(Interfaces::CEnumerable<decltype(link)>);
+    return IsPartialPoint(link);
+}
+} // namespace Platform::Data
+
+template<typename TLinkAddress> struct std::hash<Platform::Data::Point<TLinkAddress>>
 {
     std::size_t operator()(const Platform::Data::Point<TLinkAddress>& self) const noexcept
     {
         return self.Index;
     }
 };
-

--- a/cpp/Platform.Data/Universal/IUniLinks.h
+++ b/cpp/Platform.Data/Universal/IUniLinks.h
@@ -4,22 +4,29 @@
 
 namespace Platform::Data::Universal
 {
-    public partial interface IUniLinks<TLinkAddress>
-    {
-        IList<IList<IList<TLinkAddress>>> Trigger(IList<TLinkAddress> &condition, IList<TLinkAddress> &substitution);
-    }
-
-    public partial interface IUniLinks<TLinkAddress>
-    {
-        TLinkAddress Trigger(IList<TLinkAddress> &patternOrCondition, Func<IList<TLinkAddress>, TLinkAddress> matchHandler,
-                      IList<TLinkAddress> &substitution, Func<IList<TLinkAddress>, IList<TLinkAddress>, TLinkAddress> substitutionHandler);
-
-        TLinkAddress Trigger(IList<TLinkAddress> &restriction, Func<IList<TLinkAddress>, IList<TLinkAddress>, TLinkAddress> matchedHandler,
-              IList<TLinkAddress> &substitution, Func<IList<TLinkAddress>, IList<TLinkAddress>, TLinkAddress> substitutedHandler);
-    }
-
-    public partial interface IUniLinks<TLinkAddress>
-    {
-        virtual TLinkAddress Count(IList<TLinkAddress> &restriction) = 0;
-    }
+public
+partial interface IUniLinks<TLinkAddress>
+{
+    IList<IList<IList<TLinkAddress>>> Trigger(IList<TLinkAddress> & condition, IList<TLinkAddress> & substitution);
 }
+
+public
+partial interface IUniLinks<TLinkAddress>
+{
+    TLinkAddress Trigger(IList<TLinkAddress> & patternOrCondition,
+                         Func<IList<TLinkAddress>, TLinkAddress> matchHandler,
+                         IList<TLinkAddress> & substitution,
+                         Func<IList<TLinkAddress>, IList<TLinkAddress>, TLinkAddress> substitutionHandler);
+
+    TLinkAddress Trigger(IList<TLinkAddress> & restriction,
+                         Func<IList<TLinkAddress>, IList<TLinkAddress>, TLinkAddress> matchedHandler,
+                         IList<TLinkAddress> & substitution,
+                         Func<IList<TLinkAddress>, IList<TLinkAddress>, TLinkAddress> substitutedHandler);
+}
+
+public
+partial interface IUniLinks<TLinkAddress>
+{
+    virtual TLinkAddress Count(IList<TLinkAddress> & restriction) = 0;
+}
+} // namespace Platform::Data::Universal

--- a/cpp/Platform.Data/Universal/IUniLinksCRUD.h
+++ b/cpp/Platform.Data/Universal/IUniLinksCRUD.h
@@ -4,14 +4,14 @@
 
 namespace Platform::Data::Universal
 {
-    template <typename ...> class IUniLinksCRUD;
-    template <typename TLinkAddress> class IUniLinksCRUD<TLinkAddress>
-    {
-    public:
-        virtual TLinkAddress Read(std::int32_t partType, TLinkAddress link) = 0;
-        virtual TLinkAddress Read(Func<TLinkAddress, bool> handler, IList<TLinkAddress> &pattern) = 0;
-        virtual TLinkAddress Create(IList<TLinkAddress> &parts) = 0;
-        virtual TLinkAddress Update(IList<TLinkAddress> &before, IList<TLinkAddress> &after) = 0;
-        virtual void Delete(IList<TLinkAddress> &parts) = 0;
-    };
-}
+template<typename...> class IUniLinksCRUD;
+template<typename TLinkAddress> class IUniLinksCRUD<TLinkAddress>
+{
+public:
+    virtual TLinkAddress Read(std::int32_t partType, TLinkAddress link) = 0;
+    virtual TLinkAddress Read(Func<TLinkAddress, bool> handler, IList<TLinkAddress>& pattern) = 0;
+    virtual TLinkAddress Create(IList<TLinkAddress>& parts) = 0;
+    virtual TLinkAddress Update(IList<TLinkAddress>& before, IList<TLinkAddress>& after) = 0;
+    virtual void Delete(IList<TLinkAddress>& parts) = 0;
+};
+} // namespace Platform::Data::Universal

--- a/cpp/Platform.Data/Universal/IUniLinksGS.h
+++ b/cpp/Platform.Data/Universal/IUniLinksGS.h
@@ -4,12 +4,12 @@
 
 namespace Platform::Data::Universal
 {
-    template <typename ...> class IUniLinksGS;
-    template <typename TLinkAddress> class IUniLinksGS<TLinkAddress>
-    {
-    public:
-        virtual TLinkAddress Get(std::int32_t partType, TLinkAddress link) = 0;
-        virtual TLinkAddress Get(Func<TLinkAddress, bool> handler, IList<TLinkAddress> &pattern) = 0;
-        virtual TLinkAddress Set(IList<TLinkAddress> &before, IList<TLinkAddress> &after) = 0;
-    };
-}
+template<typename...> class IUniLinksGS;
+template<typename TLinkAddress> class IUniLinksGS<TLinkAddress>
+{
+public:
+    virtual TLinkAddress Get(std::int32_t partType, TLinkAddress link) = 0;
+    virtual TLinkAddress Get(Func<TLinkAddress, bool> handler, IList<TLinkAddress>& pattern) = 0;
+    virtual TLinkAddress Set(IList<TLinkAddress>& before, IList<TLinkAddress>& after) = 0;
+};
+} // namespace Platform::Data::Universal

--- a/cpp/Platform.Data/Universal/IUniLinksIO.h
+++ b/cpp/Platform.Data/Universal/IUniLinksIO.h
@@ -4,12 +4,12 @@
 
 namespace Platform::Data::Universal
 {
-    template <typename ...> class IUniLinksIO;
-    template <typename TLinkAddress> class IUniLinksIO<TLinkAddress>
-    {
-    public:
-        virtual bool Out(Func<IList<TLinkAddress>, bool> handler, IList<TLinkAddress> &pattern) = 0;
+template<typename...> class IUniLinksIO;
+template<typename TLinkAddress> class IUniLinksIO<TLinkAddress>
+{
+public:
+    virtual bool Out(Func<IList<TLinkAddress>, bool> handler, IList<TLinkAddress>& pattern) = 0;
 
-        virtual TLinkAddress In(IList<TLinkAddress> &before, IList<TLinkAddress> &after) = 0;
-    };
-}
+    virtual TLinkAddress In(IList<TLinkAddress>& before, IList<TLinkAddress>& after) = 0;
+};
+} // namespace Platform::Data::Universal

--- a/cpp/Platform.Data/Universal/IUniLinksIOWithExtensions.h
+++ b/cpp/Platform.Data/Universal/IUniLinksIOWithExtensions.h
@@ -2,14 +2,14 @@
 
 namespace Platform::Data::Universal
 {
-    template <typename ...> class IUniLinksIOWithExtensions;
-    template <typename TLinkAddress> class IUniLinksIOWithExtensions<TLinkAddress> : public IUniLinksIO<TLinkAddress>
-    {
-    public:
-        virtual TLinkAddress OutOne(std::int32_t partType, IList<TLinkAddress> &pattern) = 0;
+template<typename...> class IUniLinksIOWithExtensions;
+template<typename TLinkAddress> class IUniLinksIOWithExtensions<TLinkAddress> : public IUniLinksIO<TLinkAddress>
+{
+public:
+    virtual TLinkAddress OutOne(std::int32_t partType, IList<TLinkAddress>& pattern) = 0;
 
-        IList<IList<TLinkAddress>> OutAll(IList<TLinkAddress> &pattern);
+    IList<IList<TLinkAddress>> OutAll(IList<TLinkAddress>& pattern);
 
-        virtual std::uint64_t OutCount(IList<TLinkAddress> &pattern) = 0;
-    };
-}
+    virtual std::uint64_t OutCount(IList<TLinkAddress>& pattern) = 0;
+};
+} // namespace Platform::Data::Universal

--- a/cpp/Platform.Data/Universal/IUniLinksRW.h
+++ b/cpp/Platform.Data/Universal/IUniLinksRW.h
@@ -4,12 +4,12 @@
 
 namespace Platform::Data::Universal
 {
-    template <typename ...> class IUniLinksRW;
-    template <typename TLinkAddress> class IUniLinksRW<TLinkAddress>
-    {
-    public:
-        virtual TLinkAddress Read(std::int32_t partType, TLinkAddress link) = 0;
-        virtual bool Read(Func<TLinkAddress, bool> handler, IList<TLinkAddress> &pattern) = 0;
-        virtual TLinkAddress Write(IList<TLinkAddress> &before, IList<TLinkAddress> &after) = 0;
-    };
-}
+template<typename...> class IUniLinksRW;
+template<typename TLinkAddress> class IUniLinksRW<TLinkAddress>
+{
+public:
+    virtual TLinkAddress Read(std::int32_t partType, TLinkAddress link) = 0;
+    virtual bool Read(Func<TLinkAddress, bool> handler, IList<TLinkAddress>& pattern) = 0;
+    virtual TLinkAddress Write(IList<TLinkAddress>& before, IList<TLinkAddress>& after) = 0;
+};
+} // namespace Platform::Data::Universal

--- a/cpp/Platform.Data/WriteHandlerState.h
+++ b/cpp/Platform.Data/WriteHandlerState.h
@@ -1,36 +1,41 @@
 namespace Platform::Data
 {
-    using namespace Platform::Interfaces;
-    template<typename TStorage>
-    struct WriteHandlerState
+using namespace Platform::Interfaces;
+template<typename TStorage> struct WriteHandlerState
+{
+    typename TStorage::LinkAddressType Break;
+    typename TStorage::LinkAddressType Result = 0;
+    std::function<typename TStorage::LinkAddressType(std::vector<typename TStorage::LinkAddressType>,
+                                                     std::vector<typename TStorage::LinkAddressType>)>
+        Handler;
+
+    WriteHandlerState(typename TStorage::LinkAddressType $continue,
+                      typename TStorage::LinkAddressType $break,
+                      auto&& handler)
+        : Result{$continue}, Break{$break}, Handler{handler}
     {
-        typename TStorage::LinkAddressType Break;
-        typename TStorage::LinkAddressType Result = 0;
-        std::function<typename TStorage::LinkAddressType(std::vector<typename TStorage::LinkAddressType>, std::vector<typename TStorage::LinkAddressType>)> Handler;
+    }
 
-        WriteHandlerState(typename TStorage::LinkAddressType $continue, typename TStorage::LinkAddressType $break, auto&& handler) :
-            Result{$continue}, Break{$break}, Handler{handler} {}
-
-        typename TStorage::LinkAddressType Apply(typename TStorage::LinkAddressType result)
+    typename TStorage::LinkAddressType Apply(typename TStorage::LinkAddressType result)
+    {
+        if (Break == result)
         {
-            if (Break == result)
-            {
-                Result = Break;
-                Handler = nullptr;
-            }
+            Result = Break;
+            Handler = nullptr;
+        }
+        return Result;
+    }
+
+    typename TStorage::LinkAddressType Handle(auto&&... args)
+    {
+        if (nullptr == Handler)
+        {
             return Result;
         }
-
-        typename TStorage::LinkAddressType Handle(auto&& ...args)
+        else
         {
-            if(nullptr == Handler)
-            {
-                return Result;
-            }
-            else
-            {
-                return Apply({Handler(std::forward<decltype(args)>(args)...)});
-            }
+            return Apply({Handler(std::forward<decltype(args)>(args)...)});
         }
-    };
-}
+    }
+};
+} // namespace Platform::Data

--- a/format-apply.sh
+++ b/format-apply.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Format apply script similar to spotlessApply for Java
+# This script formats all C++ files according to .clang-format
+
+set -e
+
+echo "Applying C++ code formatting..."
+
+# Find all C++ files
+cpp_files=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" | grep -E "^./cpp/")
+
+if [ -z "$cpp_files" ]; then
+    echo "No C++ files found to format"
+    exit 0
+fi
+
+# Check if clang-format is available
+if ! command -v clang-format &> /dev/null; then
+    echo "Error: clang-format is not installed"
+    echo "Please install clang-format to use this script"
+    exit 1
+fi
+
+# Count total files
+total_files=$(echo "$cpp_files" | wc -l)
+echo "Found $total_files C++ files to format"
+
+# Apply formatting
+file_count=0
+formatted_files=0
+
+for file in $cpp_files; do
+    file_count=$((file_count + 1))
+    echo "Formatting ($file_count/$total_files): $file"
+    
+    # Create backup
+    cp "$file" "$file.backup"
+    
+    # Apply formatting
+    if clang-format -i "$file"; then
+        # Check if file was actually changed
+        if ! cmp -s "$file" "$file.backup"; then
+            formatted_files=$((formatted_files + 1))
+        fi
+        rm "$file.backup"
+    else
+        echo "Warning: Failed to format $file"
+        mv "$file.backup" "$file"
+    fi
+done
+
+echo ""
+echo "✅ Formatting complete!"
+echo "   Total files processed: $total_files"
+echo "   Files modified: $formatted_files"
+
+if [ $formatted_files -gt 0 ]; then
+    echo ""
+    echo "Files have been formatted. Please review the changes before committing."
+fi

--- a/format-check.sh
+++ b/format-check.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Format check script similar to spotlessCheck for Java
+# This script checks if all C++ files are properly formatted
+
+set -e
+
+echo "Checking C++ code formatting..."
+
+# Find all C++ files
+cpp_files=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" | grep -E "^./cpp/")
+
+if [ -z "$cpp_files" ]; then
+    echo "No C++ files found to check"
+    exit 0
+fi
+
+# Check if clang-format is available
+if ! command -v clang-format &> /dev/null; then
+    echo "Error: clang-format is not installed"
+    echo "Please install clang-format to use this script"
+    exit 1
+fi
+
+# Count total files
+total_files=$(echo "$cpp_files" | wc -l)
+echo "Found $total_files C++ files to check"
+
+# Check formatting
+unformatted_files=()
+file_count=0
+
+for file in $cpp_files; do
+    file_count=$((file_count + 1))
+    echo "Checking ($file_count/$total_files): $file"
+    
+    if ! clang-format --dry-run --Werror "$file" >/dev/null 2>&1; then
+        unformatted_files+=("$file")
+    fi
+done
+
+# Report results
+if [ ${#unformatted_files[@]} -eq 0 ]; then
+    echo "✅ All C++ files are properly formatted!"
+    exit 0
+else
+    echo "❌ Found ${#unformatted_files[@]} files that need formatting:"
+    printf '  %s\n' "${unformatted_files[@]}"
+    echo ""
+    echo "Run './format-apply.sh' to fix formatting issues"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

This PR addresses issue #127 by implementing consistent C++ code formatting using clang-format, similar to how Java projects use `./gradlew spotlessCheck` and `./gradlew spotlessApply`.

### Changes Made

- ✅ **Added `.clang-format` configuration** - Defines consistent style rules for all C++ code
- ✅ **Formatted all 29 C++ files** - Applied consistent formatting to existing codebase using clang-format
- ✅ **Created formatting scripts**:
  - `./format-check.sh` - Equivalent to `./gradlew spotlessCheck` for C++
  - `./format-apply.sh` - Equivalent to `./gradlew spotlessApply` for C++
- ✅ **Added GitHub Actions workflow** - Automatically checks PR formatting and rejects if style violations found
- ✅ **Updated README.md** - Added documentation for formatting commands and CI integration

### Format Scripts Usage

**Check formatting** (similar to `./gradlew spotlessCheck`):
```bash
./format-check.sh
```

**Apply formatting** (similar to `./gradlew spotlessApply`):
```bash
./format-apply.sh
```

### CI Integration

Pull requests now automatically check C++ code formatting. If formatting issues are found, the PR will fail until code is properly formatted, ensuring consistent code style across all contributions.

## Test Plan

- [x] Applied formatting to all existing C++ files (29 files processed)
- [x] Verified format-check.sh passes on formatted code  
- [x] Tested format-apply.sh script functionality
- [x] Added GitHub Actions workflow for automated checking
- [x] Updated documentation in README.md

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #127