### PR TITLE
Make Constants.Null usable as universal constant for empty values/links/objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/124
+Your prepared branch: issue-124-422c39b3
+Your prepared working directory: /tmp/gh-issue-solver-1757580858762
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/124
-Your prepared branch: issue-124-422c39b3
-Your prepared working directory: /tmp/gh-issue-solver-1757580858762
-
-Proceed.

--- a/csharp/Platform.Data.Tests/LinksConstantsTests.cs
+++ b/csharp/Platform.Data.Tests/LinksConstantsTests.cs
@@ -42,6 +42,32 @@ namespace Platform.Data.Tests
             TestExternalReferences<ushort, short>();
             TestExternalReferences<byte, sbyte>();
         }
+
+        /// <summary>
+        /// <para>
+        /// Tests that null checking methods work correctly.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        [Fact]
+        public static void NullCheckingTest()
+        {
+            var constants = new LinksConstants<ulong>();
+            
+            // Test IsNull method
+            Assert.True(constants.IsNull(constants.Null));
+            Assert.True(constants.IsNull(0UL)); // Null is default which is 0 for ulong
+            Assert.False(constants.IsNull(1UL));
+            Assert.False(constants.IsNull(constants.Any));
+            Assert.False(constants.IsNull(constants.Continue));
+            
+            // Test IsNotNull method
+            Assert.False(constants.IsNotNull(constants.Null));
+            Assert.False(constants.IsNotNull(0UL)); // Null is default which is 0 for ulong
+            Assert.True(constants.IsNotNull(1UL));
+            Assert.True(constants.IsNotNull(constants.Any));
+            Assert.True(constants.IsNotNull(constants.Continue));
+        }
         private static void TestExternalReferences<TUnsigned, TSigned>() where TUnsigned : IUnsignedNumber<TUnsigned> where TSigned : ISignedNumber<TSigned>
         {
             var unsingedOne = TUnsigned.One;

--- a/csharp/Platform.Data/LinksConstantsExtensions.cs
+++ b/csharp/Platform.Data/LinksConstantsExtensions.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
+using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
@@ -87,5 +88,55 @@ namespace Platform.Data
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsExternalReference<TLinkAddress>(this LinksConstants<TLinkAddress> linksConstants, TLinkAddress address) where TLinkAddress : IUnsignedNumber<TLinkAddress> => linksConstants.ExternalReferencesRange?.Contains(address) ?? false;
+
+        /// <summary>
+        /// <para>
+        /// Determines whether the specified address is null (empty value).
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <typeparam name="TLinkAddress">
+        /// <para>The link address.</para>
+        /// <para></para>
+        /// </typeparam>
+        /// <param name="linksConstants">
+        /// <para>The links constants.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="address">
+        /// <para>The address.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>True if the address equals Constants.Null; otherwise, false</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNull<TLinkAddress>(this LinksConstants<TLinkAddress> linksConstants, TLinkAddress address) where TLinkAddress : IUnsignedNumber<TLinkAddress> => EqualityComparer<TLinkAddress>.Default.Equals(address, linksConstants.Null);
+
+        /// <summary>
+        /// <para>
+        /// Determines whether the specified address is not null (not empty value).
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <typeparam name="TLinkAddress">
+        /// <para>The link address.</para>
+        /// <para></para>
+        /// </typeparam>
+        /// <param name="linksConstants">
+        /// <para>The links constants.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="address">
+        /// <para>The address.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>True if the address does not equal Constants.Null; otherwise, false</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNotNull<TLinkAddress>(this LinksConstants<TLinkAddress> linksConstants, TLinkAddress address) where TLinkAddress : IUnsignedNumber<TLinkAddress> => !EqualityComparer<TLinkAddress>.Default.Equals(address, linksConstants.Null);
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the functionality requested in issue #124 to make `Constants.Null` usable as a universal constant for empty values/links/objects.

### Changes Made

- ✅ **Added `IsNull` extension method** to `LinksConstantsExtensions` 
  - Provides convenient way to check if a link address equals `Constants.Null`
  - Uses `EqualityComparer<TLinkAddress>.Default` for consistent null checking
  
- ✅ **Added `IsNotNull` extension method** to `LinksConstantsExtensions`
  - Provides convenient way to check if a link address does not equal `Constants.Null`
  - Complementary method for better code readability

- ✅ **Added comprehensive unit tests** in `LinksConstantsTests`
  - Tests both methods with various scenarios
  - Verifies behavior with `Constants.Null`, literal `0UL`, and other constant values
  - Ensures methods work correctly with the default null value

### Technical Details

Both methods follow the established patterns in the codebase:
- Consistent XML documentation format
- `AggressiveInlining` attribute for performance
- Generic type constraints matching other extension methods
- Integration with existing `LinksConstants<TLinkAddress>` infrastructure

### Usage Examples

```csharp
var constants = new LinksConstants<ulong>();

// Check if a link is null
if (constants.IsNull(someLink))
{
    // Handle null case
}

// Check if a link is not null
if (constants.IsNotNull(someLink))
{
    // Process valid link
}

// Works with Constants.Null directly
Assert.True(constants.IsNull(constants.Null));
```

### Test Results

All tests pass successfully:
- ✅ Original tests continue to pass
- ✅ New `NullCheckingTest` validates the implementation
- ✅ Build completes without errors

## Fixes

Fixes #124

---

🤖 Generated with [Claude Code](https://claude.ai/code)