### PR TITLE
Remove nullable markers from required handler parameters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/121
+Your prepared branch: issue-121-4319a89f
+Your prepared working directory: /tmp/gh-issue-solver-1757585217308
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/121
-Your prepared branch: issue-121-4319a89f
-Your prepared working directory: /tmp/gh-issue-solver-1757585217308
-
-Proceed.

--- a/csharp/Platform.Data/ILinks.cs
+++ b/csharp/Platform.Data/ILinks.cs
@@ -60,7 +60,7 @@ namespace Platform.Data
         /// <param name="handler"><para>A handler for each matching link.</para><para>Обработчик для каждой подходящей связи.</para></param>
         /// <returns><para>Constants.Continue, if the pass through the links was not interrupted, and Constants.Break otherwise.</para><para>Constants.Continue, в случае если проход по связям не был прерван и Constants.Break в обратном случае.</para></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        TLinkAddress Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress>? handler);
+        TLinkAddress Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress> handler);
 
         #endregion
 
@@ -89,7 +89,7 @@ namespace Platform.Data
         /// </para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler);
+        TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress> handler);
 
         /// <summary>
         /// Обновляет связь с указанными restriction[Constants.IndexPart] в адресом связи
@@ -117,7 +117,7 @@ namespace Platform.Data
         /// </para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        TLinkAddress Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler);
+        TLinkAddress Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress> handler);
 
         /// <summary>
         /// <para>Deletes links that match the specified restriction.</para>
@@ -142,7 +142,7 @@ namespace Platform.Data
         /// </para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        TLinkAddress Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler);
+        TLinkAddress Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress> handler);
 
         #endregion
     }

--- a/csharp/Platform.Data/ILinksExtensions.cs
+++ b/csharp/Platform.Data/ILinksExtensions.cs
@@ -127,7 +127,7 @@ namespace Platform.Data
         /// <param name="restrictions">Ограничения на содержимое связей. Каждое ограничение может иметь значения: Constants.Null - 0-я связь, обозначающая ссылку на пустоту, Any - отсутствие ограничения, 1..∞ конкретный индекс связи.</param>
         /// <returns>True, в случае если проход по связям не был прерван и False в обратном случае.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TLinkAddress Each<TLinkAddress, TConstants>(this ILinks<TLinkAddress, TConstants> links, ReadHandler<TLinkAddress>? handler, params TLinkAddress[] restrictions) where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        public static TLinkAddress Each<TLinkAddress, TConstants>(this ILinks<TLinkAddress, TConstants> links, ReadHandler<TLinkAddress> handler, params TLinkAddress[] restrictions) where TLinkAddress : IUnsignedNumber<TLinkAddress>
             where TConstants : LinksConstants<TLinkAddress>
             => links.Each(restrictions, handler);
 


### PR DESCRIPTION
## Summary

Fixed issue #121 by removing `?` nullable markers from handler parameters that are required in ILinks interface methods.

## Changes Made

Removed nullable markers from the following parameters:

### ILinks Interface (`Platform.Data/ILinks.cs`)
- `Each` method: `ReadHandler<TLinkAddress> handler` (was `ReadHandler<TLinkAddress>? handler`)
- `Create` method: `WriteHandler<TLinkAddress> handler` (was `WriteHandler<TLinkAddress>? handler`)  
- `Update` method: `WriteHandler<TLinkAddress> handler` (was `WriteHandler<TLinkAddress>? handler`)
- `Delete` method: `WriteHandler<TLinkAddress> handler` (was `WriteHandler<TLinkAddress>? handler`)

### ILinksExtensions (`Platform.Data/ILinksExtensions.cs`)
- `Each` extension method: `ReadHandler<TLinkAddress> handler` (was `ReadHandler<TLinkAddress>? handler`)

## Rationale

These handler parameters are functionally required for the methods to work properly:
- For `Each`: A handler is needed to process each matching link
- For `Create/Update/Delete`: A handler is needed to process the results of write operations

Marking them as non-nullable improves the API contract and prevents null reference exceptions.

## Test Results

- ✅ All existing tests pass (3/3 passed)
- ✅ Build succeeds with no compilation errors
- ✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #121