### PR TITLE
Remove External Zero concept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/120
-Your prepared branch: issue-120-931c65ea
-Your prepared working directory: /tmp/gh-issue-solver-1757591781076
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/120
+Your prepared branch: issue-120-931c65ea
+Your prepared working directory: /tmp/gh-issue-solver-1757591781076
+
+Proceed.

--- a/cpp/Platform.Data.Tests/LinksConstantsTests.cpp
+++ b/cpp/Platform.Data.Tests/LinksConstantsTests.cpp
@@ -5,7 +5,7 @@
         using namespace Platform::Data;
 
         auto constants = LinksConstants<std::uint64_t>(true);
-        ASSERT_EQ(Hybrid<std::uint64_t>::ExternalZero, constants.ExternalReferencesRange.Minimum);
+        ASSERT_EQ(std::uint64_t{0}, constants.ExternalReferencesRange.Minimum);
         ASSERT_EQ(std::numeric_limits<std::uint64_t>::max(), constants.ExternalReferencesRange.Maximum);
     }
 

--- a/cpp/Platform.Data/Hybrid.h
+++ b/cpp/Platform.Data/Hybrid.h
@@ -13,13 +13,12 @@
     class Hybrid
     {
         public: static constexpr TLinkAddress HalfOfNumberValuesRange = std::numeric_limits<TLinkAddress>::max() / 2;
-        public: static constexpr TLinkAddress ExternalZero = static_cast<TLinkAddress>(HalfOfNumberValuesRange + 1);
 
         public: const TLinkAddress Value = 0;
 
         public: [[nodiscard]] bool IsNothing() const noexcept
         {
-            return (Value == ExternalZero) || (SignedValue() == 0);
+            return Value == 0;
         }
 
         public: [[nodiscard]] bool IsInternal() const noexcept
@@ -29,7 +28,7 @@
 
         public: [[nodiscard]] bool IsExternal() const noexcept
         {
-            return (Value == ExternalZero) || (SignedValue() < 0);
+            return (Value == 0) || (SignedValue() < 0);
         }
 
         public: [[nodiscard]] auto SignedValue() const noexcept -> decltype(Internal::smart_to_signed(Value))
@@ -39,7 +38,7 @@
 
         public: [[nodiscard]] TLinkAddress AbsoluteValue() const noexcept
         {
-            return (Value == ExternalZero) ? 0 : std::abs(SignedValue());
+            return (Value == 0) ? 0 : std::abs(SignedValue());
         }
 
         public: explicit Hybrid(TLinkAddress value) noexcept : Value(value) { }
@@ -58,7 +57,7 @@
         {
             if (value == 0 && isExternal)
             {
-                return ExternalZero;
+                return 0;
             }
             else
             {

--- a/cpp/Platform.Data/LinksConstants.h
+++ b/cpp/Platform.Data/LinksConstants.h
@@ -116,7 +116,7 @@
         {
             if (enableExternalReferencesSupport)
             {
-                return Ranges::Range{Hybrid<TLinkAddress>::ExternalZero, std::numeric_limits<TLinkAddress>::max()};
+                return Ranges::Range{TLinkAddress{0}, std::numeric_limits<TLinkAddress>::max()};
             }
             else
             {

--- a/csharp/Platform.Data.Tests/LinksConstantsTests.cs
+++ b/csharp/Platform.Data.Tests/LinksConstantsTests.cs
@@ -24,7 +24,7 @@ namespace Platform.Data.Tests
         public static void ConstructorTest()
         {
             var constants = new LinksConstants<ulong>(enableExternalReferencesSupport: true);
-            Assert.Equal(Hybrid<ulong>.ExternalZero, constants.ExternalReferencesRange.Value.Minimum);
+            Assert.Equal((ulong)0, constants.ExternalReferencesRange.Value.Minimum);
             Assert.Equal(ulong.MaxValue, constants.ExternalReferencesRange.Value.Maximum);
         }
 

--- a/csharp/Platform.Data/Hybrid.cs
+++ b/csharp/Platform.Data/Hybrid.cs
@@ -30,13 +30,6 @@ namespace Platform.Data
         /// <para></para>
         /// </summary>
         public static readonly TLinkAddress HalfOfNumberValuesRange = (NumericType<TLinkAddress>.MaxValue) / TLinkAddress.CreateTruncating(2);
-        /// <summary>
-        /// <para>
-        /// The half of number values range.
-        /// </para>
-        /// <para></para>
-        /// </summary>
-        public static readonly TLinkAddress ExternalZero = (HalfOfNumberValuesRange + TLinkAddress.CreateTruncating(1));
 
         /// <summary>
         /// <para>
@@ -55,7 +48,7 @@ namespace Platform.Data
         public bool IsNothing
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (Value == ExternalZero) || SignedValue == 0;
+            get => Value == default;
         }
 
         /// <summary>
@@ -79,7 +72,7 @@ namespace Platform.Data
         public bool IsExternal
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (Value == ExternalZero) || SignedValue < 0;
+            get => (Value == default) || SignedValue < 0;
         }
 
         /// <summary>
@@ -103,7 +96,7 @@ namespace Platform.Data
         public long AbsoluteValue
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (Value == ExternalZero) ? 0 : System.Math.Abs(SignedValue);
+            get => (Value == default) ? 0 : System.Math.Abs(SignedValue);
         }
 
         /// <summary>
@@ -142,7 +135,7 @@ namespace Platform.Data
         {
             if ((value == default) && isExternal)
             {
-                Value = ExternalZero;
+                Value = default;
             }
             else
             {
@@ -190,7 +183,7 @@ namespace Platform.Data
             var signedValue = value == null ? 0 : _objectToInt64Converter.Convert(value);
             if (signedValue == 0 && isExternal)
             {
-                Value = ExternalZero;
+                Value = default;
             }
             else
             {

--- a/csharp/Platform.Data/LinksConstants.cs
+++ b/csharp/Platform.Data/LinksConstants.cs
@@ -287,7 +287,7 @@ namespace Platform.Data
         {
             if (enableExternalReferencesSupport)
             {
-                return (Hybrid<TLinkAddress>.ExternalZero, NumericType<TLinkAddress>.MaxValue);
+                return (TLinkAddress.CreateTruncating(0), NumericType<TLinkAddress>.MaxValue);
             }
             else
             {


### PR DESCRIPTION
## Summary

This PR implements the removal of the ExternalZero concept as requested in issue #120.

### Changes Made

- **Removed ExternalZero constant** from both C# (`Hybrid.cs`) and C++ (`Hybrid.h`) implementations
- **Updated logic in key properties**:
  - `IsNothing`: Now simply checks `Value == default` (C#) or `Value == 0` (C++)
  - `IsExternal`: Uses `(Value == default) || SignedValue < 0` instead of ExternalZero check
  - `AbsoluteValue`: Uses `(Value == default) ? 0 : Math.Abs(SignedValue)` pattern
- **Modified constructors** to assign `default`/`0` instead of `ExternalZero` for external zero values
- **Updated LinksConstants** to use zero as the minimum external reference range
- **Updated unit tests** to expect zero instead of ExternalZero in test assertions

### Impact

As described in the issue, this change brings:

**Pros:**
✅ Bitwise operations safety  
✅ Better performance with conversion of raw numbers  
✅ Zeros in memory managers are now searchable  

**Cons:**
⚠️ Worse performance of memory managers (additional if branches for zero and indexing of zero values)  
⚠️ Large change across the codebase  

### Test Results

- C# project builds successfully with no compilation errors
- All ExternalZero references have been completely removed from the codebase
- Unit tests updated to reflect the new zero handling behavior

Fixes #120

🤖 Generated with [Claude Code](https://claude.ai/code)