### PR TITLE
Move restrictions before substitution in Update method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/113
+Your prepared branch: issue-113-dca088a9
+Your prepared working directory: /tmp/gh-issue-solver-1757708307945
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/113
-Your prepared branch: issue-113-dca088a9
-Your prepared working directory: /tmp/gh-issue-solver-1757708307945
-
-Proceed.

--- a/cpp/Platform.Data.Tests/ILinksTests.cpp
+++ b/cpp/Platform.Data.Tests/ILinksTests.cpp
@@ -31,6 +31,7 @@ namespace Platform::Data::Tests
         const TLinkAddress linkAddress {1};
         Create(storage, linkAddress);
         Update(storage, TLink{1}, TLink{1, 1});
+        Update(storage, TLink{1, 1}, linkAddress);  // Test new variadic Update method
         storage.Count(TLink{1});
         const_links.Count(TLink{1});
         storage.Each(TLink{1}, [](const TLink& link){ return 1; });

--- a/cpp/Platform.Data/ILinksExtensions.h
+++ b/cpp/Platform.Data/ILinksExtensions.h
@@ -89,6 +89,13 @@
         typename TStorage::LinkType restrictionContainer { static_cast<typename TStorage::LinkAddressType>(restriction)... };
         return DIRECT_METHOD_CALL(TStorage, storage, Each, restrictionContainer, handler);
     }
+    
+    template<typename TStorage>
+    static typename TStorage::LinkAddressType Update(TStorage& storage, const typename TStorage::LinkType& substitution, std::convertible_to<typename TStorage::LinkAddressType> auto... restrictions)
+    {
+        typename TStorage::LinkType restrictionContainer { static_cast<typename TStorage::LinkAddressType>(restrictions)... };
+        return Update(storage, restrictionContainer, substitution);
+    }
 
     template<typename TStorage>
     static typename TStorage::LinkType GetLink(const TStorage& storage, typename TStorage::LinkAddressType linkAddress)


### PR DESCRIPTION
## Summary
- Added a new variadic template `Update` method to `ILinksExtensions.h` that properly handles parameter order
- The new method takes a substitution and variadic restrictions, then calls the base `Update` method with restrictions before substitution
- Added a test case to verify the new method works correctly

## Test plan
- [x] Added test case in `ILinksTests.cpp` to verify the new `Update` method
- [x] Verified the method follows the same pattern as other variadic template methods in the file
- [x] Confirmed the method calls the base `Update` method with correct parameter order (restrictions before substitution)

Fixes #113

🤖 Generated with [Claude Code](https://claude.ai/code)