### PR TITLE
Make WriteHandlerState.Handler nullable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/102
-Your prepared branch: issue-102-d07ee3c7
-Your prepared working directory: /tmp/gh-issue-solver-1757715593710
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/102
+Your prepared branch: issue-102-d07ee3c7
+Your prepared working directory: /tmp/gh-issue-solver-1757715593710
+
+Proceed.

--- a/cpp/Platform.Data/WriteHandlerState.h
+++ b/cpp/Platform.Data/WriteHandlerState.h
@@ -10,6 +10,9 @@ namespace Platform::Data
 
         WriteHandlerState(typename TStorage::LinkAddressType $continue, typename TStorage::LinkAddressType $break, auto&& handler) :
             Result{$continue}, Break{$break}, Handler{handler} {}
+        
+        WriteHandlerState(typename TStorage::LinkAddressType $continue, typename TStorage::LinkAddressType $break, std::nullptr_t) :
+            Result{$continue}, Break{$break}, Handler{nullptr} {}
 
         typename TStorage::LinkAddressType Apply(typename TStorage::LinkAddressType result)
         {


### PR DESCRIPTION
## Summary

- Added constructor overload to accept `nullptr` for Handler parameter in C++ version
- This matches the nullable behavior already present in the C# version (`WriteHandler<TLinkAddress>? handler`)
- Allows creating `WriteHandlerState` instances with null handlers when no handler is needed initially

## Changes Made

### C++ (`WriteHandlerState.h`)
- Added new constructor: `WriteHandlerState(typename TStorage::LinkAddressType $continue, typename TStorage::LinkAddressType $break, std::nullptr_t)`
- Existing null-checking logic in `Handle()` method already supports nullable handlers
- No breaking changes to existing API

### C# (No changes needed)
- Already supports nullable handlers via `WriteHandler<TLinkAddress>? handler` parameter

## Test Plan

- ✅ Created and tested standalone C++ program to verify nullable handler functionality
- ✅ Verified existing C# tests still pass
- ✅ Confirmed no compilation errors in C++ version
- ✅ Validated that existing null-checking logic works correctly

Fixes #102

🤖 Generated with [Claude Code](https://claude.ai/code)