### PR TITLE
Fix parameter name inconsistency in Create method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/80
-Your prepared branch: issue-80-d054f677
-Your prepared working directory: /tmp/gh-issue-solver-1757724477284
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/80
+Your prepared branch: issue-80-d054f677
+Your prepared working directory: /tmp/gh-issue-solver-1757724477284
+
+Proceed.

--- a/csharp/Platform.Data/ILinks.cs
+++ b/csharp/Platform.Data/ILinks.cs
@@ -69,7 +69,7 @@ namespace Platform.Data
         /// <summary>
         /// <para>Creates a link.</para>
         /// <para>Создаёт связь.</para>
-        /// <param name="substitution">
+        /// <param name="restriction">
         /// <para>The content of a new link. This argument is optional, if the null passed as value that means no content of a link is set.</para>
         /// <para>Содержимое новой связи. Этот аргумент опционален, если null передан в качестве значения это означает, что никакого содержимого для связи не установлено.</para>
         /// </param>
@@ -89,7 +89,7 @@ namespace Platform.Data
         /// </para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler);
+        TLinkAddress Create(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler);
 
         /// <summary>
         /// Обновляет связь с указанными restriction[Constants.IndexPart] в адресом связи


### PR DESCRIPTION
## Summary
- Changed parameter name from `substitution` to `restriction` in the `ILinks.Create` method to maintain consistency with other methods in the interface
- Updated XML documentation to reflect the parameter name change
- For create operations, restriction is assumed empty as noted in issue #80

## Test plan
- [x] Code compiles successfully without errors
- [x] All existing tests pass
- [x] Parameter naming is now consistent across all ILinks interface methods

Fixes #80

🤖 Generated with [Claude Code](https://claude.ai/code)