### PR TITLE
Fix GetLink method to throw exception when link does not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/72
+Your prepared branch: issue-72-67b8d7f8
+Your prepared working directory: /tmp/gh-issue-solver-1757746999417
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/72
-Your prepared branch: issue-72-67b8d7f8
-Your prepared working directory: /tmp/gh-issue-solver-1757746999417
-
-Proceed.

--- a/csharp/Platform.Data.Tests/ILinksExtensionsTests.cs
+++ b/csharp/Platform.Data.Tests/ILinksExtensionsTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Xunit;
+using Platform.Data.Exceptions;
+using Platform.Delegates;
+
+namespace Platform.Data.Tests
+{
+    /// <summary>
+    /// Tests for ILinksExtensions methods
+    /// </summary>
+    public static class ILinksExtensionsTests
+    {
+        private class MockLinks : ILinks<ulong, LinksConstants<ulong>>
+        {
+            private readonly LinksConstants<ulong> _constants;
+
+            public MockLinks()
+            {
+                _constants = new LinksConstants<ulong>(enableExternalReferencesSupport: true);
+            }
+
+            public LinksConstants<ulong> Constants => _constants;
+
+            public ulong Count(IList<ulong>? restriction) => 0;
+
+            public ulong Each(IList<ulong>? restriction, ReadHandler<ulong>? handler)
+            {
+                // Return Constants.Break to simulate no matching links found
+                return _constants.Break;
+            }
+
+            public ulong Create(IList<ulong>? substitution, WriteHandler<ulong>? handler) => 0;
+
+            public ulong Update(IList<ulong>? restriction, IList<ulong>? substitution, WriteHandler<ulong>? handler) => 0;
+
+            public ulong Delete(IList<ulong>? restriction, WriteHandler<ulong>? handler) => 0;
+        }
+
+        /// <summary>
+        /// Tests that GetLink throws ArgumentLinkDoesNotExistsException when link doesn't exist
+        /// </summary>
+        [Fact]
+        public static void GetLinkThrowsExceptionWhenLinkDoesNotExist()
+        {
+            var links = new MockLinks();
+            var nonExistentLinkId = 999UL;
+
+            // The mock implementation returns Constants.Break from Each, which means no link was found
+            // and the Setter.Result remains null, so GetLink should throw ArgumentLinkDoesNotExistsException
+            var exception = Assert.Throws<ArgumentLinkDoesNotExistsException<ulong>>(() => 
+                links.GetLink(nonExistentLinkId));
+
+            // Verify the exception contains the correct link id (checking if it's in the message)
+            Assert.Contains(nonExistentLinkId.ToString(), exception.Message);
+        }
+
+        /// <summary>
+        /// Tests that GetLink works correctly for external references
+        /// </summary>
+        [Fact]
+        public static void GetLinkWorksForExternalReferences()
+        {
+            var links = new MockLinks();
+            var externalReference = new Hybrid<ulong>(0, true); // External reference
+
+            // For external references, GetLink should return a Point without calling Each
+            var result = links.GetLink(externalReference);
+
+            Assert.NotNull(result);
+            // The Point should contain the external reference value
+            Assert.Equal(externalReference.Value, result[0]);
+        }
+    }
+}

--- a/csharp/Platform.Data/ILinksExtensions.cs
+++ b/csharp/Platform.Data/ILinksExtensions.cs
@@ -148,7 +148,12 @@ namespace Platform.Data
             }
             var linkPartsSetter = new Setter<IList<TLinkAddress>?, TLinkAddress>(constants.Continue, constants.Break);
             links.Each(linkPartsSetter.SetAndReturnTrue, link);
-            return linkPartsSetter.Result;
+            var result = linkPartsSetter.Result;
+            if (result == null)
+            {
+                throw new ArgumentLinkDoesNotExistsException<TLinkAddress>(link);
+            }
+            return result;
         }
 
         #region Points


### PR DESCRIPTION
## Summary

Fixes issue #72 by adding proper error handling in the `GetLink` method in `ILinksExtensions.cs`.

The issue was that when a link doesn't exist (is not an external reference and has no data in the links storage), the `Setter.Result` would remain null, but the method was returning this null value without checking. Later methods like `IsFullPoint` and `IsPartialPoint` would receive this null value and fail when calling `Ensure.Always.ArgumentNotEmpty(link, nameof(link))`.

### Changes made:

- **Fix in `GetLink` method** (`ILinksExtensions.cs:141-157`): Added null check after `links.Each()` call. If the result is null (meaning no link was found), the method now throws `ArgumentLinkDoesNotExistsException<TLinkAddress>` with the link address that was not found.

- **Added comprehensive tests** (`ILinksExtensionsTests.cs`): Created unit tests to verify:
  - The method throws the correct exception when a link doesn't exist
  - The method works correctly for external references (existing behavior preserved)
  - The exception contains the correct link address in the error message

### Behavior before fix:
- `GetLink` would return `null` for non-existent links
- Downstream methods would fail with unclear errors when processing `null` values

### Behavior after fix:
- `GetLink` throws `ArgumentLinkDoesNotExistsException<TLinkAddress>` immediately when link is not found
- Clear error message indicating which specific link does not exist
- Consistent with existing error handling patterns in the codebase (similar to `EnsureLinkExists` method)

## Test plan

- [x] Unit tests pass for both exception case and normal operation
- [x] Existing tests continue to pass (no regressions)
- [x] Build succeeds without compilation errors
- [x] Exception message contains the correct link address for debugging

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #72