### PR TITLE
Rename Size property to Count to reduce number of properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/63
+Your prepared branch: issue-63-41cd36c5
+Your prepared working directory: /tmp/gh-issue-solver-1757756668112
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/63
-Your prepared branch: issue-63-41cd36c5
-Your prepared working directory: /tmp/gh-issue-solver-1757756668112
-
-Proceed.

--- a/csharp/Platform.Data/Point.cs
+++ b/csharp/Platform.Data/Point.cs
@@ -34,17 +34,6 @@ namespace Platform.Data
             get;
         }
 
-        /// <summary>
-        /// <para>
-        /// Gets the size value.
-        /// </para>
-        /// <para></para>
-        /// </summary>
-        public int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get;
-        }
 
         /// <summary>
         /// <para>
@@ -57,7 +46,7 @@ namespace Platform.Data
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                if (index < Size)
+                if (index < Count)
                 {
                     return Index;
                 }
@@ -79,7 +68,7 @@ namespace Platform.Data
         public int Count
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Size;
+            get;
         }
 
         /// <summary>
@@ -104,15 +93,15 @@ namespace Platform.Data
         /// <para>A index.</para>
         /// <para></para>
         /// </param>
-        /// <param name="size">
-        /// <para>A size.</para>
+        /// <param name="count">
+        /// <para>A count.</para>
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Point(TLinkAddress index, int size)
+        public Point(TLinkAddress index, int count)
         {
             Index = index;
-            Size = size;
+            Count = count;
         }
 
         /// <summary>
@@ -184,7 +173,7 @@ namespace Platform.Data
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerator<TLinkAddress> GetEnumerator()
         {
-            for (int i = 0; i < Size; i++)
+            for (int i = 0; i < Count; i++)
             {
                 yield return Index;
             }
@@ -267,7 +256,7 @@ namespace Platform.Data
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         IEnumerator IEnumerable.GetEnumerator()
         {
-            for (int i = 0; i < Size; i++)
+            for (int i = 0; i < Count; i++)
             {
                 yield return Index;
             }


### PR DESCRIPTION
## Summary

This PR addresses issue #63 by removing the redundant `Size` property from the `Point<TLinkAddress>` class and consolidating it with the existing `Count` property.

### Changes made:
- ✅ Removed the `Size` property declaration
- ✅ Updated the `Count` property to be a direct property instead of returning `Size`
- ✅ Changed constructor parameter from `size` to `count` for consistency
- ✅ Updated all internal references from `Size` to `Count` in:
  - Indexer bounds checking
  - For loops in `GetEnumerator()` methods
  - Constructor assignment

### Benefits:
- **Reduced complexity**: Eliminates redundant property, reducing the total number of properties in the class
- **Improved clarity**: Single property `Count` is more intuitive and aligns with standard .NET collection interfaces
- **Better maintainability**: Less code to maintain and fewer potential inconsistencies

## Test plan

- ✅ All existing tests pass (3/3 tests successful)
- ✅ Code builds successfully without compilation errors
- ✅ Verified no external dependencies on the `Size` property exist in the codebase

**Fixes #63**

🤖 Generated with [Claude Code](https://claude.ai/code)