### PR TITLE
Fix indexing operators to validate negative indices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/62
-Your prepared branch: issue-62-1aaf4256
-Your prepared working directory: /tmp/gh-issue-solver-1757762816036
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/62
+Your prepared branch: issue-62-1aaf4256
+Your prepared working directory: /tmp/gh-issue-solver-1757762816036
+
+Proceed.

--- a/csharp/Platform.Data/LinkAddress.cs
+++ b/csharp/Platform.Data/LinkAddress.cs
@@ -42,14 +42,11 @@ namespace Platform.Data
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                if (index == 0)
-                {
-                    return Index;
-                }
-                else
+                if (index != 0)
                 {
                     throw new IndexOutOfRangeException();
                 }
+                return Index;
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => throw new NotSupportedException();

--- a/csharp/Platform.Data/Point.cs
+++ b/csharp/Platform.Data/Point.cs
@@ -57,14 +57,11 @@ namespace Platform.Data
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                if (index < Size)
-                {
-                    return Index;
-                }
-                else
+                if (index < 0 || index >= Size)
                 {
                     throw new IndexOutOfRangeException();
                 }
+                return Index;
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => throw new NotSupportedException();

--- a/examples/experiments/IndexerTest.cs
+++ b/examples/experiments/IndexerTest.cs
@@ -1,0 +1,101 @@
+using System;
+using Platform.Data;
+
+namespace Platform.Data.Tests
+{
+    public class IndexerTest
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Testing Point<ulong> indexer...");
+            var point = new Point<ulong>(42UL, 3);
+            
+            // Test valid indices
+            try
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    Console.WriteLine($"point[{i}] = {point[i]}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Unexpected error with valid indices: {ex.Message}");
+            }
+            
+            // Test negative index (should throw)
+            try
+            {
+                var result = point[-1];
+                Console.WriteLine($"ERROR: Negative index should have thrown exception, but got: {result}");
+            }
+            catch (IndexOutOfRangeException)
+            {
+                Console.WriteLine("✓ Negative index correctly throws IndexOutOfRangeException");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: Unexpected exception type: {ex.GetType().Name}: {ex.Message}");
+            }
+            
+            // Test out-of-bounds index (should throw)
+            try
+            {
+                var result = point[3];
+                Console.WriteLine($"ERROR: Out-of-bounds index should have thrown exception, but got: {result}");
+            }
+            catch (IndexOutOfRangeException)
+            {
+                Console.WriteLine("✓ Out-of-bounds index correctly throws IndexOutOfRangeException");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: Unexpected exception type: {ex.GetType().Name}: {ex.Message}");
+            }
+            
+            Console.WriteLine();
+            Console.WriteLine("Testing LinkAddress<ulong> indexer...");
+            var linkAddress = new LinkAddress<ulong>(123UL);
+            
+            // Test valid index (0)
+            try
+            {
+                Console.WriteLine($"linkAddress[0] = {linkAddress[0]}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Unexpected error with valid index 0: {ex.Message}");
+            }
+            
+            // Test negative index (should throw)
+            try
+            {
+                var result = linkAddress[-1];
+                Console.WriteLine($"ERROR: Negative index should have thrown exception, but got: {result}");
+            }
+            catch (IndexOutOfRangeException)
+            {
+                Console.WriteLine("✓ Negative index correctly throws IndexOutOfRangeException");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: Unexpected exception type: {ex.GetType().Name}: {ex.Message}");
+            }
+            
+            // Test positive index other than 0 (should throw)
+            try
+            {
+                var result = linkAddress[1];
+                Console.WriteLine($"ERROR: Index 1 should have thrown exception, but got: {result}");
+            }
+            catch (IndexOutOfRangeException)
+            {
+                Console.WriteLine("✓ Index 1 correctly throws IndexOutOfRangeException");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: Unexpected exception type: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+    }
+}

--- a/examples/experiments/IndexerTest.csproj
+++ b/examples/experiments/IndexerTest.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../../csharp/Platform.Data/Platform.Data.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Fixed indexing operators in `Point<T>` and `LinkAddress<T>` classes to properly validate negative indices
- Added check for `index < 0` in Point<T> indexer to prevent invalid negative access  
- Refactored LinkAddress<T> indexer to use cleaner `index != 0` validation
- Both indexers now correctly throw `IndexOutOfRangeException` for all invalid indices

## Changes Made
- **Point.cs:60**: Changed `if (index < Size)` to `if (index < 0 || index >= Size)` 
- **LinkAddress.cs:45**: Changed `if (index == 0)` to `if (index != 0)` for better readability

## Test plan
- ✅ Created and ran comprehensive indexer validation tests
- ✅ Verified negative indices now properly throw `IndexOutOfRangeException`
- ✅ Confirmed valid indices still return expected values
- ✅ All existing tests continue to pass

Fixes #62

🤖 Generated with [Claude Code](https://claude.ai/code)