### PR TITLE
Make Count method an optimization by providing default implementation using Each

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/53
-Your prepared branch: issue-53-f1fcdfa0
-Your prepared working directory: /tmp/gh-issue-solver-1757778580859
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/53
+Your prepared branch: issue-53-f1fcdfa0
+Your prepared working directory: /tmp/gh-issue-solver-1757778580859
+
+Proceed.

--- a/csharp/Platform.Data/ILinks.cs
+++ b/csharp/Platform.Data/ILinks.cs
@@ -46,8 +46,21 @@ namespace Platform.Data
         /// </summary>
         /// <param name="restriction"><para>Restriction on the contents of links.</para><para>Ограничение на содержимое связей.</para></param>
         /// <returns><para>The total number of links in the storage that meet the specified restriction.</para><para>Общее число связей находящихся в хранилище, соответствующих указанному ограничению.</para></returns>
+        /// <remarks>
+        /// <para>This method is an optimization. It can be implemented using the Each method, but this default implementation may not be efficient enough for all use cases.</para>
+        /// <para>Этот метод является оптимизацией. Он может быть реализован с использованием метода Each, но эта реализация по умолчанию может быть недостаточно эффективной для всех случаев использования.</para>
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        TLinkAddress Count(IList<TLinkAddress>? restriction);
+        TLinkAddress Count(IList<TLinkAddress>? restriction)
+        {
+            var counter = TLinkAddress.Zero;
+            Each(restriction, link =>
+            {
+                counter++;
+                return Constants.Continue;
+            });
+            return counter;
+        }
 
         /// <summary>
         /// <para>Passes through all the links matching the pattern, invoking a handler for each matching link.</para>


### PR DESCRIPTION
## Summary

This PR addresses issue #53 by making the `Count` method an optimization rather than a basic method. The solution provides a default implementation in the `ILinks` interface that uses the `Each` method to count links.

## Changes Made

- **Added default implementation**: The `Count` method now has a default implementation in the interface that uses the `Each` method to count matching links
- **Added documentation**: Added remarks explaining that this is an optimization method that can be overridden for better performance
- **Preserved compatibility**: All existing code continues to work without changes

## Technical Details

The default implementation:
```csharp
TLinkAddress Count(IList<TLinkAddress>? restriction)
{
    var counter = TLinkAddress.Zero;
    Each(restriction, link =>
    {
        counter++;
        return Constants.Continue;
    });
    return counter;
}
```

This approach allows:
1. **Basic functionality**: Works out of the box for any implementation that provides `Each`
2. **Optimization opportunity**: Implementations can override this method with more efficient counting mechanisms
3. **Backward compatibility**: All existing code continues to work

## Testing

- All existing tests pass ✅
- Build completes successfully ✅
- No breaking changes introduced ✅

## Related

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)