### PR TITLE
Complete Sequences namespace cleanup from PackageTags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/47
+Your prepared branch: issue-47-2e3a8bd2
+Your prepared working directory: /tmp/gh-issue-solver-1757790015997
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/47
-Your prepared branch: issue-47-2e3a8bd2
-Your prepared working directory: /tmp/gh-issue-solver-1757790015997
-
-Proceed.

--- a/csharp/Platform.Data/Platform.Data.csproj
+++ b/csharp/Platform.Data/Platform.Data.csproj
@@ -4,12 +4,12 @@
     <Description>LinksPlatform's Platform.Data Class Library</Description>
     <Copyright>konard, FreePhoenix888</Copyright>
     <AssemblyTitle>Platform.Data</AssemblyTitle>
-    <VersionPrefix>0.16.1</VersionPrefix>
+    <VersionPrefix>0.16.2</VersionPrefix>
     <Authors>konard, FreePhoenix888</Authors>
     <TargetFramework>net8</TargetFramework>
     <AssemblyName>Platform.Data</AssemblyName>
     <PackageId>Platform.Data</PackageId>
-    <PackageTags>LinksPlatform;Data;ArgumentLinkDoesNotExistsException;ArgumentLinkHasDependenciesException;LinksLimitReachedException;LinksLimitReachedExceptionBase;LinkWithSameValueAlreadyExistsException;AddressToRawNumberConverter;RawNumberToAddressConverter;ISequenceAppender;ISequenceWalker;SequenceWalker;StopableSequenceWalker;Hybrid;ILinks;ILinksExtensions;ISynchronizedLinks;LinkAddress;LinksConstants;LinksConstantsBase;LinksConstantsExtensions;Point</PackageTags>
+    <PackageTags>LinksPlatform;Data;ArgumentLinkDoesNotExistsException;ArgumentLinkHasDependenciesException;LinksLimitReachedException;LinksLimitReachedExceptionBase;LinkWithSameValueAlreadyExistsException;AddressToRawNumberConverter;RawNumberToAddressConverter;Hybrid;ILinks;ILinksExtensions;ISynchronizedLinks;LinkAddress;LinksConstants;LinksConstantsBase;LinksConstantsExtensions;Point</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/linksplatform/Documentation/18469f4d033ee9a5b7b84caab9c585acab2ac519/doc/Avatar-rainbow-icon-64x64.png</PackageIconUrl>
     <PackageProjectUrl>https://linksplatform.github.io/Data</PackageProjectUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
@@ -23,7 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Update target framework from net7 to net8.</PackageReleaseNotes>
+    <PackageReleaseNotes>Remove Sequences-related PackageTags that were moved to separate repository.</PackageReleaseNotes>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Remove references to Sequences-related classes from PackageTags that were moved to separate repository in 2021
- Update version from 0.16.1 to 0.16.2
- Update PackageReleaseNotes to reflect the cleanup

## Background
The Sequences namespace (including `ISequenceAppender`, `ISequenceWalker`, `SequenceWalker`, `StopableSequenceWalker`) was moved to a separate repository [Platform.Data.Sequences](https://github.com/linksplatform/Data.Sequences) in 2021 (commits aabdb01 and d867e43), but the PackageTags in Platform.Data.csproj still referenced these classes.

## Changes
- Removed `ISequenceAppender;ISequenceWalker;SequenceWalker;StopableSequenceWalker` from PackageTags
- Incremented VersionPrefix from 0.16.1 to 0.16.2
- Updated PackageReleaseNotes to describe the change

## Test plan
- [x] Verified no remaining references to moved Sequences classes exist in codebase
- [x] Confirmed PackageTags now only reference classes that exist in this repository
- [x] Version incremented appropriately for this cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #47