### PR TITLE
Utilize comments in ILinks.cs by standardizing XML documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data/issues/15
+Your prepared branch: issue-15-96609115
+Your prepared working directory: /tmp/gh-issue-solver-1757833480604
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data/issues/15
-Your prepared branch: issue-15-96609115
-Your prepared working directory: /tmp/gh-issue-solver-1757833480604
-
-Proceed.

--- a/csharp/Platform.Data/ILinks.cs
+++ b/csharp/Platform.Data/ILinks.cs
@@ -4,7 +4,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using Platform.Delegates;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Data
 {
@@ -92,16 +91,14 @@ namespace Platform.Data
         TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler);
 
         /// <summary>
-        /// Обновляет связь с указанными restriction[Constants.IndexPart] в адресом связи
-        /// на связь с указанным новым содержимым.
+        /// <para>Updates a link with the specified restriction[Constants.IndexPart] containing the link address to a link with the specified new content.</para>
+        /// <para>Обновляет связь с указанными restriction[Constants.IndexPart] в адресом связи на связь с указанным новым содержимым.</para>
         /// </summary>
         /// <param name="restriction">
-        /// Ограничение на содержимое связей.
-        /// Предполагается, что будет указан индекс связи (в restriction[Constants.IndexPart]) и далее за ним будет следовать содержимое связи.
-        /// Каждое ограничение может иметь значения: Constants.Null - 0-я связь, обозначающая ссылку на пустоту,
-        /// Constants.Itself - требование установить ссылку на себя, 1..∞ конкретный индекс другой связи.
+        /// <para>Restriction on the contents of links. It is assumed that the link index will be specified (in restriction[Constants.IndexPart]) and then the link content will follow. Each constraint can have values: Constants.Null - the 0th link denoting a reference to the void, Constants.Itself - a requirement to set a reference to itself, 1..∞ a specific index of another link.</para>
+        /// <para>Ограничение на содержимое связей. Предполагается, что будет указан индекс связи (в restriction[Constants.IndexPart]) и далее за ним будет следовать содержимое связи. Каждое ограничение может иметь значения: Constants.Null - 0-я связь, обозначающая ссылку на пустоту, Constants.Itself - требование установить ссылку на себя, 1..∞ конкретный индекс другой связи.</para>
         /// </param>
-        /// <param name="substitution"></param>
+        /// <param name="substitution"><para>The new content of the link.</para><para>Новое содержимое связи.</para></param>
         /// <param name="handler">
         /// <para>A function to handle each executed change. This function can use Constants.Continue to continue proccess each change. Constants.Break can be used to stop receiving of executed changes.</para>
         /// <para>Функция для обработки каждого выполненного изменения. Эта функция может использовать Constants.Continue чтобы продолжить обрабатывать каждое изменение. Constants.Break может быть использована для остановки получения выполненных изменений.</para>


### PR DESCRIPTION
## Summary
- Converted Russian-only comments for Update method to proper bilingual XML documentation format following the established pattern in the codebase
- Removed `#pragma warning disable CS1591` to enable XML documentation warnings and enforce documentation completeness
- Ensured consistency across all public interface members with standardized bilingual documentation (English and Russian)

## Changes Made
- **Lines 95-102**: Converted Russian-only comments to proper XML documentation with both English and Russian descriptions
- **Line 7**: Removed pragma directive to enable XML documentation validation
- **Parameter documentation**: Added missing English documentation for the `substitution` parameter

## Benefits
- Consistent documentation format across the entire interface
- Better IDE support with proper XML documentation 
- Enables XML documentation warnings to catch missing documentation in the future
- Follows the established bilingual documentation pattern used throughout the codebase

## Test Results
- ✅ All existing tests pass
- ✅ Project builds successfully  
- ✅ XML documentation warnings now properly enforced

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #15